### PR TITLE
Python 3.9 fixes

### DIFF
--- a/BaseTools/Source/Python/AutoGen/UniClassObject.py
+++ b/BaseTools/Source/Python/AutoGen/UniClassObject.py
@@ -152,7 +152,7 @@ class Ucs2Codec(codecs.Codec):
 
 TheUcs2Codec = Ucs2Codec()
 def Ucs2Search(name):
-    if name == 'ucs-2':
+    if name in ['ucs-2', 'ucs_2']:
         return codecs.CodecInfo(
             name=name,
             encode=TheUcs2Codec.encode,

--- a/BaseTools/Source/Python/Common/Misc.py
+++ b/BaseTools/Source/Python/Common/Misc.py
@@ -1635,7 +1635,7 @@ class PeImageClass():
         ByteArray = array.array('B')
         ByteArray.fromfile(PeObject, 4)
         # PE signature should be 'PE\0\0'
-        if ByteArray.tostring() != b'PE\0\0':
+        if ByteArray.tolist() != [ord('P'), ord('E'), 0, 0]:
             self.ErrorInfo = self.FileName + ' has no valid PE signature PE00'
             return
 

--- a/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
+++ b/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
@@ -27,10 +27,11 @@ from Common.TargetTxtClassObject import TargetTxtDict
 from Common.ToolDefClassObject import ToolDefDict
 from AutoGen.BuildEngine import ToolBuildRule
 import Common.DataType as DataType
-from Common.Misc import PathClass
+from Common.Misc import PathClass,CreateDirectory
 from Common.LongFilePathSupport import OpenLongFilePath as open
 from Common.MultipleWorkspace import MultipleWorkspace as mws
 import Common.GlobalData as GlobalData
+from Common.BuildToolError import *
 
 ## Global variables
 #
@@ -463,12 +464,28 @@ class GenFdsGlobalVariable:
                     GenFdsGlobalVariable.SecCmdList.append(' '.join(Cmd).strip())
             else:
                 SectionData = array('B', [0, 0, 0, 0])
-                SectionData.fromstring(Ui.encode("utf_16_le"))
+                SectionData.fromlist(array('B',Ui.encode('utf-16-le')).tolist())
                 SectionData.append(0)
                 SectionData.append(0)
                 Len = len(SectionData)
                 GenFdsGlobalVariable.SectionHeader.pack_into(SectionData, 0, Len & 0xff, (Len >> 8) & 0xff, (Len >> 16) & 0xff, 0x15)
-                SaveFileOnChange(Output, SectionData.tostring())
+
+
+                DirName = os.path.dirname(Output)
+                if not CreateDirectory(DirName):
+                    EdkLogger.error(None, FILE_CREATE_FAILURE, "Could not create directory %s" % DirName)
+                else:
+                    if DirName == '':
+                        DirName = os.getcwd()
+                    if not os.access(DirName, os.W_OK):
+                        EdkLogger.error(None, PERMISSION_FAILURE, "Do not have write permission on directory %s" % DirName)
+
+                try:
+                    with open(Output, "wb") as Fd:
+                        SectionData.tofile(Fd)
+                        Fd.flush()
+                except IOError as X:
+                    EdkLogger.error(None, FILE_CREATE_FAILURE, ExtraData='IOError %s' % X)
 
         elif Ver:
             Cmd += ("-n", Ver)


### PR DESCRIPTION
Pull in fixes from upstream that fix building with Python 3.9. This allows us to use the latest `coreboot-sdk` for compiling UEFIPayload.