### PR TITLE
UefiPayloadPkg/Include/Coreboot.h: Bump CB_TAG_LOGO value

### DIFF
--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -255,7 +255,7 @@ struct cb_smmstorev2 {
 	UINT8 unused[3];	/* Set to zero */
 };
 
-#define CB_TAG_LOGO       0x0042
+#define CB_TAG_LOGO       0x00a0
 
 struct cb_bootlogo_header {
 	UINT64 size;


### PR DESCRIPTION
Bump CB_TAG_LOGO to a higher value to avoid colliding with other
cbmem tags as they're added in upstream coreboot.

Breaks compatibility with previous persistent bootsplash implementation
in coreboot.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>