### PR TITLE
Loosen vboot version checks

### DIFF
--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -578,7 +578,6 @@ enum vb2_nv_recovery {
 
 /* Current version of vb2_shared_data struct */
 #define VB2_SHARED_DATA_VERSION_MAJOR 3
-#define VB2_SHARED_DATA_VERSION_MINOR 1
 
 #define VB2_SHARED_DATA_MAGIC 0x44533256
 

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -946,9 +946,9 @@ ParseVBootWorkbuf (
     DEBUG ((DEBUG_INFO, "VBootWorkbuf tag data is wrong\n"));
     return RETURN_NOT_FOUND;
   }
-  if (Workbuf->struct_version_major != VB2_SHARED_DATA_VERSION_MAJOR ||
-      Workbuf->struct_version_minor != VB2_SHARED_DATA_VERSION_MINOR) {
-    DEBUG ((DEBUG_INFO, "VBootWorkbuf tag data is of wrong version\n"));
+
+  if (Workbuf->struct_version_major != VB2_SHARED_DATA_VERSION_MAJOR) {
+    DEBUG ((DEBUG_INFO, "VBootWorkbuf tag data is of wrong major version\n"));
     return RETURN_NOT_FOUND;
   }
 


### PR DESCRIPTION
Don't require minor version to match, all structs of the same major version should be compatible.