### PR TITLE
UefiPayloadPkg: Add PCD for default SecureBoot state

### DIFF
--- a/UefiPayloadPkg/SecureBootEnrollDefaultKeys/SecureBootSetup.inf
+++ b/UefiPayloadPkg/SecureBootEnrollDefaultKeys/SecureBootSetup.inf
@@ -28,6 +28,7 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   SecurityPkg/SecurityPkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
 
 [Guids]
   gEfiCertPkcs7Guid
@@ -45,10 +46,14 @@
   UefiDriverEntryPoint
   DxeServicesLib
   UefiBootServicesTableLib
+  PcdLib
 
 [Protocols]
   gEfiTcgProtocolGuid ##CONSUMES
   gEfiVariableWriteArchProtocolGuid                  ## NOTIFY
+
+[Pcd]
+  gUefiPayloadPkgTokenSpaceGuid.PcdSecureBootDefaultEnable
 
 [Depex]
   TRUE

--- a/UefiPayloadPkg/UefiPayloadPkg.dec
+++ b/UefiPayloadPkg/UefiPayloadPkg.dec
@@ -75,6 +75,7 @@ gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData|0xC0|UINT32|0x
 gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode|0x80|UINT32|0x00000016
 
 gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|TRUE|BOOLEAN|0x00000017
+gUefiPayloadPkgTokenSpaceGuid.PcdSecureBootDefaultEnable|TRUE|BOOLEAN|0x00000018
 
 [PcdsFixedAtBuild]
 ## Specifies the initial value for Register_A in RTC.

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -92,6 +92,7 @@
   DEFINE SATA_PASSWORD_ENABLE         = FALSE
   DEFINE OPAL_PASSWORD_ENABLE         = FALSE
   DEFINE LOAD_OPTION_ROMS             = TRUE
+  DEFINE SECURE_BOOT_DEFAULT_ENABLE   = TRUE
   #
   # Network definition
   #
@@ -398,6 +399,7 @@
   gUefiPayloadPkgTokenSpaceGuid.PcdBootMenuKey|$(BOOT_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdSetupMenuKey|$(SETUP_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|$(LOAD_OPTION_ROMS)
+  gUefiPayloadPkgTokenSpaceGuid.PcdSecureBootDefaultEnable|$(SECURE_BOOT_DEFAULT_ENABLE)
 
 !if $(SOURCE_DEBUG_ENABLE)
   gEfiSourceLevelDebugPkgTokenSpaceGuid.PcdDebugLoadImageMethod|0x2

--- a/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkgIa32X64.dsc
@@ -92,6 +92,7 @@
   DEFINE SATA_PASSWORD_ENABLE         = FALSE
   DEFINE OPAL_PASSWORD_ENABLE         = FALSE
   DEFINE LOAD_OPTION_ROMS             = TRUE
+  DEFINE SECURE_BOOT_DEFAULT_ENABLE   = TRUE
   #
   # Network definition
   #
@@ -394,6 +395,7 @@
   gUefiPayloadPkgTokenSpaceGuid.PcdBootMenuKey|$(BOOT_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdSetupMenuKey|$(SETUP_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|$(LOAD_OPTION_ROMS)
+  gUefiPayloadPkgTokenSpaceGuid.PcdSecureBootDefaultEnable|$(SECURE_BOOT_DEFAULT_ENABLE)
 
 !if $(SOURCE_DEBUG_ENABLE)
   gEfiSourceLevelDebugPkgTokenSpaceGuid.PcdDebugLoadImageMethod|0x2


### PR DESCRIPTION
Add PCD to make default Secure Boot enablement controllable. Default to TRUE to maintain compatibility.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>