### PR TITLE
Opal fixes

### DIFF
--- a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
+++ b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
@@ -905,3 +905,34 @@ Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (
 
   return TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS;
 }
+
+/**
+  Return TPM2 ManagementFlags set by PP interface.
+
+  @retval    ManagementFlags    TPM2 Management Flags.
+**/
+UINT32
+EFIAPI
+Tcg2PhysicalPresenceLibGetManagementFlags (
+  VOID
+  )
+{
+  EFI_STATUS                        Status;
+  EFI_TCG2_PHYSICAL_PRESENCE_FLAGS  PpiFlags;
+  UINTN                             DataSize;
+
+  DEBUG ((EFI_D_INFO, "[TPM2] GetManagementFlags\n"));
+
+  DataSize = sizeof (EFI_TCG2_PHYSICAL_PRESENCE_FLAGS);
+  Status = gRT->GetVariable (
+                  TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE,
+                  &gEfiTcg2PhysicalPresenceGuid,
+                  NULL,
+                  &DataSize,
+                  &PpiFlags
+                  );
+  if (EFI_ERROR (Status)) {
+    PpiFlags.PPFlags = TCG2_BIOS_TPM_MANAGEMENT_FLAG_DEFAULT | TCG2_BIOS_STORAGE_MANAGEMENT_FLAG_DEFAULT;
+  }
+  return PpiFlags.PPFlags;
+}

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -2668,10 +2668,6 @@ OpalEfiDriverBindingSupported(
   EFI_STATUS                              Status;
   EFI_STORAGE_SECURITY_COMMAND_PROTOCOL*  SecurityCommand;
 
-  if (mOpalEndOfDxe) {
-    return EFI_UNSUPPORTED;
-  }
-
   //
   // Test EFI_STORAGE_SECURITY_COMMAND_PROTOCOL on controller Handle.
   //


### PR DESCRIPTION
Add missing `Tcg2PhysicalPresenceLibGetManagementFlags` function to OvmfPkg and remove EndOfDxe check from OpalPassword