### PR TITLE
Memory map fixes

### DIFF
--- a/UefiPayloadPkg/BlSupportPei/BlSupportPei.c
+++ b/UefiPayloadPkg/BlSupportPei/BlSupportPei.c
@@ -370,21 +370,7 @@ MemInfoCallback (
         }
       }
     } else if (Type == EFI_RESOURCE_MEMORY_MAPPED_IO) {
-      BuildResourceDescriptorHob (
-          EFI_RESOURCE_MEMORY_RESERVED,
-          (EFI_RESOURCE_ATTRIBUTE_PRESENT    |
-          EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
-          EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
-          EFI_RESOURCE_ATTRIBUTE_TESTED),
-          (EFI_PHYSICAL_ADDRESS)Base,
-          Size
-          );
-
-      BuildMemoryAllocationHob (
-        (EFI_PHYSICAL_ADDRESS)Base,
-        Size,
-        EfiMemoryMappedIO
-        );
+      BuildMemoryMappedIoRangeHob((EFI_PHYSICAL_ADDRESS)Base, Size);
     } else if (Type == EFI_RESOURCE_FIRMWARE_DEVICE) {
       BuildResourceDescriptorHob (
           EFI_RESOURCE_FIRMWARE_DEVICE,

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -390,7 +390,6 @@ ParseMemoryInfo (
   MEMROY_MAP_ENTRY         MemoryMap;
   UINT32                   Tolud;
 
-
   Tolud = PciRead32(PCI_LIB_ADDRESS(0,0,0,0xbc)) & 0xFFF00000;
 
   //

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -388,6 +388,10 @@ ParseMemoryInfo (
   struct cb_memory_range   *Range;
   UINTN                    Index;
   MEMROY_MAP_ENTRY         MemoryMap;
+  UINT32                   Tolud;
+
+
+  Tolud = PciRead32(PCI_LIB_ADDRESS(0,0,0,0xbc)) & 0xFFF00000;
 
   //
   // Get the coreboot memory table
@@ -410,8 +414,17 @@ ParseMemoryInfo (
         break;
       /* Only MMIO is marked reserved */
       case CB_MEM_RESERVED:
-        MemoryMap.Type = EFI_RESOURCE_MEMORY_MAPPED_IO;
-        MemoryMap.Flag = EFI_RESOURCE_ATTRIBUTE_PRESENT;
+        /*
+         * Reserved memory Below TOLUD can't be MMIO except legacy VGA which
+         * is reported elsewhere as reserved.
+         */
+        if (MemoryMap.Base < Tolud) {
+          MemoryMap.Type = EFI_RESOURCE_MEMORY_RESERVED;
+          MemoryMap.Flag = EFI_RESOURCE_ATTRIBUTE_PRESENT;
+        } else {
+          MemoryMap.Type = EFI_RESOURCE_MEMORY_MAPPED_IO;
+          MemoryMap.Flag = EFI_RESOURCE_ATTRIBUTE_PRESENT;
+        }
         break;
       case CB_MEM_UNUSABLE:
         MemoryMap.Type = EFI_RESOURCE_MEMORY_RESERVED;


### PR DESCRIPTION
Fixes issues with certain dGPUs DMA errors. The UEFI memory map is incorrectly constructed. Pei driver reports all coreboot reserved resources (including MMIO) as reserved memory instead of MMIO. So MMIO and reserved memory are mixed together. The PR fixes that by checking if the resource is below TOLUD for reserved memory, if above it means MMIO. VT-d driver checks for the UEFI memory map and sets correct DMA protections, but only for memory. Before the patch it incorrectly set the protections for whole address space below 4G, now it sets the protection correctly. The TOLUD check is also required because RMRR is placed below TOLUD and it has to be reported as reserved memory, otherwise, OS complained on incorrect mapping before the fix and things could break.