### PR TITLE
Dasharo (UEFI) v0.1.0 for QEMU Q35

### DIFF
--- a/MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.c
+++ b/MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.c
@@ -25,7 +25,7 @@ typedef struct {
 } DEFERRED_3RD_PARTY_IMAGE_TABLE;
 
 BOOLEAN                          mImageLoadedAfterEndOfDxe   = FALSE;
-BOOLEAN                          mEndOfDxe                   = TRUE;
+BOOLEAN                          mEndOfDxe                   = FALSE;
 DEFERRED_3RD_PARTY_IMAGE_TABLE   mDeferred3rdPartyImage = {
   0,       // Deferred image count
   NULL     // The deferred image info

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -173,10 +173,6 @@
   LoadLinuxLib|OvmfPkg/Library/LoadLinuxLib/LoadLinuxLib.inf
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/BaseMemEncryptSevLib.inf
 
-# 
-#SMM for OVMF
-#
-
 !if $(SMM_REQUIRE) == FALSE
   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf 
 !else
@@ -184,12 +180,6 @@
 !endif
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   FrameBufferBltLib|MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.inf
-
-#
-#Misc
-#
-
-  LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
 
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
   PeCoffExtraActionLib|SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLibDebug.inf
@@ -204,9 +194,6 @@
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
 
   IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
-#
-#OPAL_PASSWORD
-#
 
 !if $(OPAL_PASSWORD_ENABLE) == TRUE
   TcgStorageCoreLib|SecurityPkg/Library/TcgStorageCoreLib/TcgStorageCoreLib.inf
@@ -619,7 +606,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio64Size|0x800000000
 !endif
 
-  gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|0
+  gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|2
 
   # Set video resolution for text setup.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution|640
@@ -725,8 +712,6 @@
 !endif
 !endif
 
-### SATA_PASSWORD
-
 !if $(SATA_PASSWORD_ENABLE) == TRUE
   SecurityPkg/HddPassword/HddPasswordPei.inf
 !endif
@@ -760,8 +745,6 @@
 !endif
   }
 
-### SETUP_PASSWORD
-
 !if $(SETUP_PASSWORD_ENABLE) == TRUE
   DasharoModulePkg/UserAuthenticationDxe/UserAuthenticationDxe.inf {
     <LibraryClasses>
@@ -791,6 +774,10 @@
   MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf {
     <LibraryClasses>
+!ifdef $(CSM_ENABLE)
+      NULL|OvmfPkg/Csm/CsmSupportLib/CsmSupportLib.inf
+      NULL|OvmfPkg/Csm/LegacyBootManagerLib/LegacyBootManagerLib.inf
+!endif
   }
   MdeModulePkg/Logo/LogoDxe.inf
   MdeModulePkg/Application/UiApp/UiApp.inf {
@@ -799,6 +786,10 @@
       NULL|DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
       NULL|MdeModulePkg/Library/BootManagerUiLib/BootManagerUiLib.inf
       NULL|MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerUiLib.inf
+!ifdef $(CSM_ENABLE)
+      NULL|OvmfPkg/Csm/LegacyBootManagerLib/LegacyBootManagerLib.inf
+      NULL|OvmfPkg/Csm/LegacyBootMaintUiLib/LegacyBootMaintUiLib.inf
+!endif
     <PcdsFixedAtBuild>
       gDasharoSystemFeaturesTokenSpaceGuid.PcdShowMenu|$(DASHARO_SYSTEM_FEATURES_ENABLE)
   }
@@ -902,7 +893,7 @@
   DasharoModulePkg/DasharoBootPolicies/DasharoBootPolicies.inf
 !endif
 
-
+  #
   # Hash2
   #
   SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf {
@@ -1043,9 +1034,6 @@
   }
 !endif
 
-  #
-  # TPM support
-  #
 !if $(TPM_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
     <LibraryClasses>
@@ -1060,13 +1048,12 @@
   }
 !if $(TPM_CONFIG_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
-!endif
-  SecurityPkg/Tcg/TcgDxe/TcgDxe.inf {
+  SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDxe.inf {
     <LibraryClasses>
       Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
   }
 !endif
-  SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDxe.inf {
+  SecurityPkg/Tcg/TcgDxe/TcgDxe.inf {
     <LibraryClasses>
       Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
   }
@@ -1076,7 +1063,7 @@
     Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
   }
 !endif
-
+!endif
 
 !if $(SATA_PASSWORD_ENABLE) == TRUE
     SecurityPkg/HddPassword/HddPasswordDxe.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -576,6 +576,18 @@
   # Point to the MdeModulePkg/Application/UiApp/UiApp.inf
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
 
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowSecurityMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIntelMeMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowUsbMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowNetworkMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowChipsetMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPowerMenu|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowFanCurve|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions|TRUE
+
 ################################################################################
 #
 # Pcd Dynamic Section - list of all EDK II PCD Entries defined by this Platform

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -584,7 +584,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowChipsetMenu|TRUE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPowerMenu|TRUE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowFanCurve|TRUE
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable|FALSE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise|TRUE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions|TRUE
 
@@ -657,6 +657,7 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2SelfTestPolicy|1
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInitializationPolicy|1
 !endif
+  gIntelSiliconPkgTokenSpaceGuid.PcdVTdPolicyPropertyMask|1
 
 [PcdsDynamicHii]
 !if $(TPM_ENABLE) == TRUE && $(TPM_CONFIG_ENABLE) == TRUE

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -35,7 +35,6 @@
   DEFINE TPM_CONFIG_ENABLE       = TRUE
   DEFINE SATA_PASSWORD_ENABLE    = TRUE
   DEFINE OPAL_PASSWORD_ENABLE    = TRUE
-  DEFINE LOAD_OPTION_ROMS        = FLASE
   DEFINE DASHARO_SYSTEM_FEATURES_ENABLE = TRUE
   DEFINE USE_CBMEM_FOR_CONSOLE   = FALSE
   DEFINE ABOVE_4G_MEMORY         = FALSE
@@ -482,7 +481,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutUgaSupport|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdInstallAcpiSdtProtocol|TRUE
 !ifdef $(CSM_ENABLE)
-  gUefiOvmfPkgTokenSpaceGuid.PcdCsmEnable|FALSE
+  gUefiOvmfPkgTokenSpaceGuid.PcdCsmEnable|TRUE
 !endif
 !if $(SMM_REQUIRE) == TRUE
   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire|TRUE
@@ -652,10 +651,6 @@
 
 !if $(TPM_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-  ### TPM Initialization.
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2InitializationPolicy|1
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2SelfTestPolicy|1
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInitializationPolicy|1
 !endif
   gIntelSiliconPkgTokenSpaceGuid.PcdVTdPolicyPropertyMask|1
 
@@ -861,12 +856,6 @@
 !endif
   OvmfPkg/QemuRamfbDxe/QemuRamfbDxe.inf
   OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
-  
-  #
-  # SMBIOS Support
-  #
-  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
-  MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.inf
 
   #
   # ISA Support

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -974,6 +974,8 @@
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+  SecurityPkg/EnrollFromDefaultKeysApp/EnrollFromDefaultKeysApp.inf
+  SecurityPkg/VariableAuthenticated/SecureBootDefaultKeysDxe/SecureBootDefaultKeysDxe.inf
   OvmfPkg/EnrollDefaultKeys/EnrollDefaultKeys.inf
 !endif
 
@@ -1062,7 +1064,10 @@
       Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
   }
 !endif
-
+  SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDxe.inf {
+    <LibraryClasses>
+      Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
+  }
 !if $(OPAL_PASSWORD_ENABLE) == TRUE
   SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordDxe.inf {
     <LibraryClasses>

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -119,6 +119,8 @@ INF  OvmfPkg/Sec/SecMain.inf
 
 INF  RuleOverride=RESET_VECTOR OvmfPkg/ResetVector/ResetVector.inf
 
+
+
 ################################################################################
 [FV.PEIFV]
 FvNameGuid         = 6938079B-B503-4E3D-9D24-B28337A25806
@@ -165,6 +167,14 @@ INF  UefiCpuPkg/CpuMpPei/CpuMpPei.inf
 INF  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
 INF  SecurityPkg/Tcg/TcgPei/TcgPei.inf
 INF  SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+!if $(OPAL_PASSWORD_ENABLE) == TRUE
+INF SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordPei.inf
+!endif
+!endif
+
+
+!if $(SATA_PASSWORD_ENABLE) == TRUE
+INF SecurityPkg/HddPassword/HddPasswordPei.inf
 !endif
 
 ################################################################################
@@ -237,6 +247,8 @@ INF  OvmfPkg/PvScsiDxe/PvScsiDxe.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+  INF  SecurityPkg/EnrollFromDefaultKeysApp/EnrollFromDefaultKeysApp.inf
+  INF  SecurityPkg/VariableAuthenticated/SecureBootDefaultKeysDxe/SecureBootDefaultKeysDxe.inf
 !endif
 
 INF  MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
@@ -249,6 +261,7 @@ INF  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
 INF  MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
 INF  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
 INF  MdeModulePkg/Application/UiApp/UiApp.inf
+INF  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 INF  OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf
 INF  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
 INF  MdeModulePkg/Universal/PrintDxe/PrintDxe.inf
@@ -275,6 +288,7 @@ INF  MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
 
 INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
 INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+INF  MdeModulePkg/Universal/SmbiosMeasurementDxe/SmbiosMeasurementDxe.inf
 
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
 INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -304,6 +318,25 @@ INF MdeModulePkg/Logo/LogoDxe.inf
 !endif
 !include NetworkPkg/Network.fdf.inc
   INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
+
+INF DasharoModulePkg/DasharoBootPolicies/DasharoBootPolicies.inf
+
+#
+# Hash2
+#
+INF SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
+
+#
+# PKCS7 Verification
+#
+INF SecurityPkg/Pkcs7Verify/Pkcs7VerifyDxe/Pkcs7VerifyDxe.inf
+
+#
+# SD/eMMC Support
+#
+INF MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
+INF MdeModulePkg/Bus/Sd/EmmcDxe/EmmcDxe.inf
+INF MdeModulePkg/Bus/Sd/SdDxe/SdDxe.inf
 
 #
 # Usb Support
@@ -365,9 +398,22 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 !if $(TPM_ENABLE) == TRUE
 INF  SecurityPkg/Tcg/TcgDxe/TcgDxe.inf
 INF  SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+INF  SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDxe.inf
+INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !if $(TPM_CONFIG_ENABLE) == TRUE
 INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
+!if $(OPAL_PASSWORD_ENABLE) == TRUE
+INF SecurityPkg/Tcg/Opal/OpalPassword/OpalPasswordDxe.inf
 !endif
+!endif
+!endif
+
+!if $(SATA_PASSWORD_ENABLE) == TRUE
+INF SecurityPkg/HddPassword/HddPasswordDxe.inf
+!endif
+
+!if $(SETUP_PASSWORD_ENABLE) == TRUE
+INF DasharoModulePkg/UserAuthenticationDxe/UserAuthenticationDxe.inf
 !endif
 
 ################################################################################

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -399,7 +399,6 @@ INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 INF  SecurityPkg/Tcg/TcgDxe/TcgDxe.inf
 INF  SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
 INF  SecurityPkg/Tcg/TcgConfigDxe/TcgConfigDxe.inf
-INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !if $(TPM_CONFIG_ENABLE) == TRUE
 INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !if $(OPAL_PASSWORD_ENABLE) == TRUE


### PR DESCRIPTION
In order to run the Dasharo OVMF in QEMU, please follow the given steps in order to build the Dasharo firmware image from the EDK2 repository and then run the firmware image using the QEMU emulator.

1. Clone the official Dasharo EDK2 repository to your local instance from https://github.com/Dasharo/edk2.git with git or downloading the source code from github. 
2. Once it is done, please follow the instructions from the `README.md` in order to prepare your environment for the building of the OVMF image. 
3. In order to build the UEFI firmware image it can be done in two ways, one way is to give the flags with `-D SMM_REQUIRE ` (SMM was actually enabled while building the firmware image, but the flags differ with feature to feature, so please check the OvmfPkgX64.dsc file). And second way is to set the flags in OvmfPkgX64.dsc and then build the firmware image. For the purpose of this documentation, I have preferred to set the features in "OvmfPkgX64.dsc" directly.
4. Check the following build command ` build -D DEBUG_ON_SERIAL_PORT -D BOOTLOADER=COREBOOT -a IA32 -a X64 -t GCC5 -b DEBUG -p OvmfPkg/OvmfPkgX64.dsc `. 

-  `DEBUG_ON_SERIAL_PORT`  = The following flag must be given for the "DEBUG" build as the output is redirected to the I/O port `0x402` to qemu monitor. We will be able to see the debug messages on the given debug I/O port. (0x402 will be later utilized in the qemu invocation further in this documentation). 
5. Once the build is completed, the OVMF firmware image can be found at ` edk2/Build/Ovmf/DEBUG_GCC5/Ovmf.fd `. 
6. Please verify your qemu installation, and invoke the qemu emulator with the built OVMF firmware image as given below.

- ` qemu-system-x86_64 -drive if=pflash,format=raw,file=Build/OvmfX64/DEBUG_GCC5/FV/OVMF.fd -nographic -debugcon file:debug.log -global isa-debugcon.iobase=0x402 -global ICH9-LPC.disable_s3=1 -net none -machine q35,smm=on `
- " The ` -drive` parameter indicates that the device is a pflash with the firmware image file pointing out to the built `OVMF.fd` image. 
- `-nographic` indicates to start the qemu emulator without any graphical output. This is useful while testing in the environment like docker. 
-  `-debugcon file:debug.log -global isa-debugcon.iobase=0x402` default OVMF build writes debug messages to IO port 0x402.  The following qemu command line options save them in the file called debug.log.
-  `-global ICH9-LPC.disable_s3=1` SMM is put to use in the S3 suspend and resume infrastructure, and in the UEFI variable driver stack. Similarly, a pflash-backed variable store is a requirement. As SMM was enabled while building the firmware image.
-  `-net none` disables the OptionROM execution which will interfere with the firmware image, if not disabled.
-  `-machine q35,smm=on` For SMM to work, only Q35 machines are supported hence the machine type.
7. After executing the above qemu command, one should be able to see the UEFI built-in shell and should be able to get to the BIOS selection area.
8. The features which are enabled in the `OvmfPkgX64.dsc` can be verified in the `BIOS menu` and also at the `Device Manager` section and the Dasharo features can be verified at the `Dasharo System Features` section.