### PR TITLE
Enable EFI Authenticated Variables

### DIFF
--- a/UefiPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntimeDxe.c
+++ b/UefiPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntimeDxe.c
@@ -153,7 +153,7 @@ InitializeFvAndVariableStoreHeaders (
   // VARIABLE_STORE_HEADER
   //
   VariableStoreHeader = (VARIABLE_STORE_HEADER *)((UINTN)Headers + FirmwareVolumeHeader->HeaderLength);
-  CopyGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid);
+  CopyGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid);
   VariableStoreHeader->Size   = PcdGet32 (PcdFlashNvStorageVariableSize) - FirmwareVolumeHeader->HeaderLength;
   VariableStoreHeader->Format = VARIABLE_STORE_FORMATTED;
   VariableStoreHeader->State  = VARIABLE_STORE_HEALTHY;


### PR DESCRIPTION
Set the variable store header to gEfiAuthenticatedVariableGuid to allow authenticated variables to work