### PR TITLE
Nvc boot optimization

### DIFF
--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.h
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiLib.h>
 #include <Library/DevicePathLib.h>
+#include <Library/PcdLib.h>
 
 #include <Protocol/DevicePath.h>
 #include <Protocol/PciIo.h>
@@ -49,7 +50,7 @@ extern EDKII_SD_MMC_OVERRIDE        *mOverride;
 //
 // Generic time out value, 1 microsecond as unit.
 //
-#define SD_MMC_HC_GENERIC_TIMEOUT     1 * 1000 * 1000
+#define SD_MMC_HC_GENERIC_TIMEOUT  (PcdGet32 (PcdSdMmcGenericTimeoutValue))
 
 //
 // SD/MMC async transfer timer interval, set by experience.

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
@@ -56,6 +56,7 @@
   BaseLib
   UefiDriverEntryPoint
   DebugLib
+  PcdLib
 
 [Protocols]
   gEdkiiSdMmcOverrideProtocolGuid               ## SOMETIMES_CONSUMES
@@ -68,3 +69,6 @@
 
 [UserExtensions.TianoCore."ExtraFiles"]
   SdMmcPciHcDxeExtra.uni
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSdMmcGenericTimeoutValue  ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1531,6 +1531,16 @@
   # @Prompt Enable Capsule On Disk support.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport|FALSE|BOOLEAN|0x0000002d
 
+  ## Maximum permitted encapsulation levels of sections in a firmware volume,
+  #  in the DXE phase. Minimum value is 1. Sections nested more deeply are
+  #  rejected.
+  # @Prompt Maximum permitted FwVol section nesting depth (exclusive).
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFwVolDxeMaxEncapsulationDepth|0x10|UINT32|0x00000030
+
+  ## Indicates the default timeout value for SD/MMC Host Controller operations in microseconds.
+  # @Prompt SD/MMC Host Controller Operations Timeout (us).
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSdMmcGenericTimeoutValue|1000000|UINT32|0x00000031
+
 [PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD defines the Console output row. The default value is 25 according to UEFI spec.
   #  This PCD could be set to 0 then console output would be at max column and max row.

--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -1175,7 +1175,11 @@
                                                                                           " TRUE  - Capsule In Ram is supported.<BR>"
                                                                                           " FALSE - Capsule In Ram is not supported."
 
-#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdCodRelocationDevPath_PROMPT  #language en-US "Capsule On Disk relacation device path."
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdSdMmcGenericTimeoutValue_PROMPT #language en-US "SD/MMC Host Controller Operations Timeout (us)."
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdSdMmcGenericTimeoutValue_HELP   #language en-US "Indicates the default timeout value for SD/MMC Host Controller operations in microseconds."
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdCodRelocationDevPath_PROMPT  #language en-US "Capsule On Disk relocation device path."
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdCodRelocationDevPath_HELP  #language en-US   "Full device path of plaform specific device to store Capsule On Disk temp relocation file.<BR>"
                                                                                            "If this PCD is set, Capsule On Disk temp relocation file will be stored in the device specified by this PCD, instead of the EFI System Partition that stores capsule image file."

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -325,8 +325,7 @@ BdsWait (
                     //         Can be removed after all keyboard drivers invoke callback in timer callback.
 
     if (HotkeyTriggered != NULL) {
-      //Status = BdsWaitForSingleEvent (HotkeyTriggered, EFI_TIMER_PERIOD_SECONDS (1));
-      Status = BdsWaitForSingleEvent (gST->ConIn->WaitForKey, EFI_TIMER_PERIOD_SECONDS (1));
+      Status = BdsWaitForSingleEvent (HotkeyTriggered, EFI_TIMER_PERIOD_SECONDS (1));
       if (!EFI_ERROR (Status)) {
         break;
       }
@@ -1024,7 +1023,7 @@ BdsEntry (
     //
     // BdsReadKeys() can be removed after all keyboard drivers invoke callback in timer callback.
     //
-    //BdsReadKeys ();
+    BdsReadKeys ();
 
     EfiBootManagerHotkeyBoot ();
 

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1088,7 +1088,9 @@ PlatformBootManagerAfterConsole (
   Black.Blue = Black.Green = Black.Red = Black.Reserved = 0;
   White.Blue = White.Green = White.Red = White.Reserved = 0xFF;
 
+  gST->ConOut->EnableCursor (gST->ConOut, FALSE);
   gST->ConOut->ClearScreen (gST->ConOut);
+
   WarnIfRecoveryBoot ();
 
   BootLogoEnableLogo ();

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -638,7 +638,6 @@ PlatformBootManagerBeforeConsole (
   VOID
 )
 {
-  EFI_INPUT_KEY                  Enter;
   EFI_INPUT_KEY                  Esc;
   EFI_INPUT_KEY                  F12;
   EFI_BOOT_MANAGER_LOAD_OPTION   BootOption;
@@ -649,12 +648,6 @@ PlatformBootManagerBeforeConsole (
   BOOLEAN                        BootMenuEnable;
   UINTN                          VarSize;
 
-  //
-  // Register ENTER as CONTINUE key
-  //
-  Enter.ScanCode    = SCAN_NULL;
-  Enter.UnicodeChar = CHAR_CARRIAGE_RETURN;
-  EfiBootManagerRegisterContinueKeyOption (0, &Enter, NULL);
   //
   // Map ESC to Boot Manager Menu
   //
@@ -1084,6 +1077,7 @@ PlatformBootManagerAfterConsole (
   BOOLEAN                        BootMenuEnable;
   UINTN                          VarSize;
   EFI_EVENT                      Event;
+  EFI_INPUT_KEY                  Enter;
 
   Black.Blue = Black.Green = Black.Red = Black.Reserved = 0;
   White.Blue = White.Green = White.Red = White.Reserved = 0xFF;
@@ -1094,6 +1088,13 @@ PlatformBootManagerAfterConsole (
   WarnIfRecoveryBoot ();
 
   BootLogoEnableLogo ();
+
+  //
+  // Register ENTER as CONTINUE key
+  //
+  Enter.ScanCode    = SCAN_NULL;
+  Enter.UnicodeChar = CHAR_CARRIAGE_RETURN;
+  EfiBootManagerRegisterContinueKeyOption (0, &Enter, NULL);
 
   // FIXME: USB devices are not being detected unless we wait a bit.
   gBS->Stall (100 * 1000);

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1040,6 +1040,26 @@ PrintSolStrings (
 }
 
 /**
+  Refresh the logo on ReadyToBoto event. It will clear the screen from strings
+  and progress bar when timeout is reached or continue key is pressed.
+
+  @param    Event          Event pointer.
+  @param    Context        Context pass to this function.
+**/
+VOID
+EFIAPI
+RefreshLogo (
+  IN EFI_EVENT    Event,
+  IN VOID         *Context
+  )
+{
+  gBS->CloseEvent (Event);
+  gBS->Stall (100 * 1000);
+  gST->ConOut->ClearScreen (gST->ConOut);
+  BootLogoEnableLogo ();
+}
+
+/**
   Do the platform specific action after the console is connected.
 
   Such as:
@@ -1063,6 +1083,7 @@ PlatformBootManagerAfterConsole (
   BOOLEAN                        NetBootEnabled;
   BOOLEAN                        BootMenuEnable;
   UINTN                          VarSize;
+  EFI_EVENT                      Event;
 
   Black.Blue = Black.Green = Black.Red = Black.Reserved = 0;
   White.Blue = White.Green = White.Red = White.Reserved = 0xFF;
@@ -1144,6 +1165,13 @@ PlatformBootManagerAfterConsole (
     Print (L"%-5s to enter Boot Manager Menu\n", BootMenuKey);
 
   Print (L"ENTER to boot directly\n");
+
+  EfiCreateEventReadyToBootEx (
+             TPL_CALLBACK,
+             RefreshLogo,
+             NULL,
+             &Event
+             );
 }
 
 /**
@@ -1174,12 +1202,6 @@ PlatformBootManagerWaitCallback (
     (Timeout - TimeoutRemain) * 100 / Timeout,
     0
     );
-
-  if (TimeoutRemain == 0) {
-    gBS->Stall (100 * 1000);
-    gST->ConOut->ClearScreen (gST->ConOut);
-    BootLogoEnableLogo ();
-  }
 }
 
 /**

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -709,6 +709,7 @@ PlatformBootManagerBeforeConsole (
   //
   FilterAndProcess (&gEfiPciRootBridgeIoProtocolGuid, NULL, Connect);
 
+  PlatformConsoleInit ();
   //
   // Find all display class PCI devices (using the handles from the previous
   // step), and connect them non-recursively. This should produce a number of
@@ -721,8 +722,6 @@ PlatformBootManagerBeforeConsole (
   // ErrOut.
   //
   FilterAndProcess (&gEfiGraphicsOutputProtocolGuid, NULL, AddOutput);
-
-  PlatformConsoleInit ();
 }
 
 CHAR16*

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1033,7 +1033,8 @@ PrintSolStrings (
 }
 
 /**
-  Refresh the logo on ReadyToBoto event. It will clear the screen from strings
+  Refresh the logo on ReadyToBoot event. It will clear the screen from strings
+
   and progress bar when timeout is reached or continue key is pressed.
 
   @param    Event          Event pointer.

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1067,7 +1067,6 @@ PlatformBootManagerAfterConsole (
   Black.Blue = Black.Green = Black.Red = Black.Reserved = 0;
   White.Blue = White.Green = White.Red = White.Reserved = 0xFF;
 
-  EfiBootManagerConnectAll ();
   gST->ConOut->ClearScreen (gST->ConOut);
   WarnIfRecoveryBoot ();
 
@@ -1075,6 +1074,7 @@ PlatformBootManagerAfterConsole (
 
   // FIXME: USB devices are not being detected unless we wait a bit.
   gBS->Stall (100 * 1000);
+  EfiBootManagerConnectAll ();
   EfiBootManagerRefreshAllBootOption ();
 
   //

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -883,6 +883,7 @@ WarnIfRecoveryBoot (
   gST->ConOut->SetAttribute (gST->ConOut, CurrentAttribute);
 
   gST->ConOut->ClearScreen (gST->ConOut);
+  DrainInput ();
 }
 
 /**

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1048,7 +1048,6 @@ RefreshLogo (
   )
 {
   gBS->CloseEvent (Event);
-  gBS->Stall (100 * 1000);
   gST->ConOut->ClearScreen (gST->ConOut);
   BootLogoEnableLogo ();
 }

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -25,7 +25,6 @@
   FLASH_DEFINITION                    = UefiPayloadPkg/UefiPayloadPkg.fdf
 
   DEFINE SOURCE_DEBUG_ENABLE          = FALSE
-
   #
   # SBL:      UEFI payload for Slim Bootloader
   # COREBOOT: UEFI payload for coreboot
@@ -98,6 +97,7 @@
   DEFINE DISABLE_MTRR_PROGRAMMING       = TRUE
   DEFINE IOMMU_ENABLE                   = FALSE
   DEFINE SETUP_PASSWORD_ENABLE          = FALSE
+  DEFINE SD_MMC_TIMEOUT                 = 1000000
 
   #
   # Network definition
@@ -419,6 +419,7 @@
   gUefiPayloadPkgTokenSpaceGuid.PcdBootMenuKey|$(BOOT_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdSetupMenuKey|$(SETUP_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|$(LOAD_OPTION_ROMS)
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSdMmcGenericTimeoutValue|$(SD_MMC_TIMEOUT)
 
 !if $(SOURCE_DEBUG_ENABLE)
   gEfiSourceLevelDebugPkgTokenSpaceGuid.PcdDebugLoadImageMethod|0x2


### PR DESCRIPTION
The PR introduced the following changes:

1. Backports an option to control SD/MMC timeout via PCD at build time (integrated in coreboot). By setting a lower timeout on SD/MMC init, it fixes the problem with long boot time on NV4x. However it does not fix https://github.com/Dasharo/dasharo-issues/issues/454
2. Reverts the change  https://github.com/Dasharo/edk2/commit/ca98d24b188813d1a919a8c75417910630c6f9d2 which broke the Continue hotkey (the enter key was passed e.g. to GRUb bootloader and one was unable to control the menu as GRUB got the key and booted its first priority)
3. Refreshes the logo at ReadyToBoot event. It results in a clear screen if Continue hotkey is used, instead of leaving half of the progress bar and strings left on the screen.