### PR TITLE
UefiPayloadPkg/UefiPayloadPkg.dsc: make the max string length bigger for 4K displays

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -422,6 +422,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
   gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|8000
+  # 4K displays may need bigger buffers for the option strings in forms
+  gEfiMdePkgTokenSpaceGuid.PcdMaximumUnicodeStringLength|2000000
   gUefiPayloadPkgTokenSpaceGuid.PcdBootMenuKey|$(BOOT_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdSetupMenuKey|$(SETUP_MENU_KEY)
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|$(LOAD_OPTION_ROMS)


### PR DESCRIPTION
Fixes issue: https://github.com/Dasharo/dasharo-issues/issues/422

When investigating cbmem logs I have noticed ASSERTS in Display Engine, but only when I entered Boot Maintenance Manager to change boot order (which triggers the issue).

[StrCpyS](https://github.com/Dasharo/edk2/blob/dasharo/MdeModulePkg/Universal/DisplayEngineDxe/ProcessOptions.c#L44) was asserting on DestMax bigger than the PcdMaximumUnicodeStringLength

Despite PcdMaximumUnicodeStringLength being set to a quite huge value of 1000000, it is not enough to hold the boot order list in Boot Maintenance Manager when using 4K display.

The reason of the buffer to be so high is the [maximum container size hardcoded to 100](https://github.com/Dasharo/edk2/blob/dasharo/MdeModulePkg/Library/BootMaintenanceManagerUiLib/UpdatePage.c#L648) which is used to calculate the [MaxLen](https://github.com/Dasharo/edk2/blob/dasharo/MdeModulePkg/Universal/DisplayEngineDxe/ProcessOptions.c#L866) used in NewStrCat function (which maps to DestMax). The BufferSize is calculated [here](https://github.com/Dasharo/edk2/blob/dasharo/MdeModulePkg/Universal/DisplayEngineDxe/ProcessOptions.c#L833) 

On a 4K display we will have the following resolution for UI: 480 x 113 glyphs. The dimensions for the statements in the form are calculated [here](https://github.com/Dasharo/edk2/blob/dasharo/MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.c#L75). Later the dimensions for statements are divided into 4 sections: Skip, Prompt, Option and Help [here](https://github.com/Dasharo/edk2/blob/dasharo/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c#L3997)
The boot order list to be displayed in Boot Maintenance Manager when changing boot order is placed in Option section.

tl;dr let's substitute the values for 4K display:

gScreenDimensions.BottomRow = 113
gScreenDimensions.RigthColumn = 480
()top and left are zeros).
gStatementDimensions.RightColumn and gStatementDimensions.LeftColumn are equal to corresponding gScreenDimensions fields.
STATUS_BAR_HEIGHT = 1
FOOTER_HEIGHT = 4
number of hotkeys in the page = 5
gFooterHeight = 4 + (number of hotkeys / 3) = 4 + (5 / 3)  = 4 +1 = 5
gStatementDimensions.BottomRow = 113 - 1 - 5 = 108

gOptionBlockWidth = (480 - 0) / 3 + 1 = 161
BufferSize = (161 + 1) * 2 * 108 = 34992;
MaxLen = 100 * 34992 / 2 = 1749600

Waaay over default 1000000 max length that is allowed by SafeString.c in BaseLib via PCD.


