### PR TITLE
UefiPayloadPkg: Support multiple consoles and debug interfaces

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -227,7 +227,7 @@
   #
   TimerLib|UefiPayloadPkg/Library/AcpiTimerLib/AcpiTimerLib.inf
   ResetSystemLib|UefiPayloadPkg/Library/ResetSystemLib/ResetSystemLib.inf
-!if $(USE_CBMEM_FOR_CONSOLE) == TRUE
+!if (($(USE_CBMEM_FOR_CONSOLE) == TRUE) && ($(TARGET) == RELEASE))
   SerialPortLib|UefiPayloadPkg/Library/CbSerialPortLib/CbSerialPortLib.inf
   PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf
 !elseif $(SYSTEM76_EC_LOGGING) == TRUE
@@ -741,7 +741,18 @@
   #
   # ISA Support
   #
-  MdeModulePkg/Universal/SerialDxe/SerialDxe.inf
+  MdeModulePkg/Universal/SerialDxe/SerialDxe.inf {
+    <LibraryClasses>
+    !if $(SYSTEM76_EC_LOGGING) == TRUE
+      SerialPortLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf
+      PlatformHookLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf
+    !else
+      SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
+      PlatformHookLib|UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
+    !endif
+  }
+
+
 !if $(PS2_KEYBOARD_ENABLE) == TRUE
   OvmfPkg/SioBusDxe/SioBusDxe.inf
   MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf


### PR DESCRIPTION
This is the truth table for various combinations of options:

| Case  | TARGET  | SERIAL_TERMINAL | MDEPKG_NDEBUG | CBMEM |  EC   | Output |
| ----- | ------- | --------------- | ------------- | ----- | ----- | ------ |
| 1.    | RELEASE |      TRUE       |               | TRUE  | FALSE | CBMEM(debug) + serial + GPU |
| 2.    | RELEASE |      TRUE       |               | TRUE  | TRUE  | CBMEM(debug) + EC + GPU |
| 3.    | RELEASE |      FALSE      |               | TRUE  | FALSE | CBMEM(debug) + GPU |
| 4.    | RELEASE |      FALSE      |               | TRUE  | TRUE  | CBMEM(debug) + GPU |
| 5.    | RELEASE |      TRUE       |    defined    | FALSE | FALSE | serial + GPU |
| 6.    | RELEASE |      TRUE       |    defined    | FALSE | TRUE  | EC + GPU |
| 7.    | RELEASE |      FALSE      |    defined    | FALSE | FALSE | GPU |
| 8.    | RELEASE |      FALSE      |    defined    | FALSE | TRUE  | GPU |
| 9.    | DEBUG   |      TRUE       |               |   X   | FALSE | serial(debug) + serial + GPU |
| 10.   | DEBUG   |      TRUE       |               |   X   | TRUE  | EC(debug) + EC + GPU |
| 11.   | DEBUG   |      FALSE      |               |   X   | FALSE | serial(debug) + GPU |
| 12.   | DEBUG   |      FALSE      |               |   X   | TRUE  | EC(debug) + GPU |

X - don't care

Libraries:

1., 5.

  Global:

  - SerialPortLib|UefiPayloadPkg/Library/CbSerialPortLib/CbSerialPortLib.inf
  - PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf

  SerialDxe:

  - SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
  - PlatformHookLib|UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf

2., 6.

  Global:

  - SerialPortLib|UefiPayloadPkg/Library/CbSerialPortLib/CbSerialPortLib.inf
  - PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf

  SerialDxe:

  - SerialPortLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf
  - PlatformHookLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf

3., 7.

  Global:

  - SerialPortLib|UefiPayloadPkg/Library/CbSerialPortLib/CbSerialPortLib.inf
  - PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf

  SerialDxe:

  - SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
  - PlatformHookLib|UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf

4., 8.

  Global:

  - SerialPortLib|UefiPayloadPkg/Library/CbSerialPortLib/CbSerialPortLib.inf
  - PlatformHookLib|MdeModulePkg/Library/BasePlatformHookLibNull/BasePlatformHookLibNull.inf

  SerialDxe:

  - SerialPortLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf
  - PlatformHookLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf

9., 11.

  Global:

  - SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
  - PlatformHookLib|UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf

  SerialDxe:

  - SerialPortLib|MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
  - PlatformHookLib|UefiPayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf

10., 12.

  Global:

  - SerialPortLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf
  - PlatformHookLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf

  SerialDxe:

  - SerialPortLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf
  - PlatformHookLib|UefiPayloadPkg/Library/System76EcLib/System76EcLib.inf