### PR TITLE
LaptopBatteryLib/LaptopBatteryLib.c: fix EC reg32 read

### DIFF
--- a/UefiPayloadPkg/Library/LaptopBatteryLib/LaptopBatteryLib.c
+++ b/UefiPayloadPkg/Library/LaptopBatteryLib/LaptopBatteryLib.c
@@ -180,6 +180,8 @@ EcReadReg32 (
   if (!Data32)
     return RETURN_INVALID_PARAMETER;
 
+  *Data32 = 0;
+
   for (Index = 0; Index < 4; Index++) {
     Status = EcReadReg(Reg + Index, &Data8[Index]);
 


### PR DESCRIPTION
fixes the battery popup always showing 0% battery and blocking boot.