### PR TITLE
MdeModulePkg/Universal/Acpi/AcpiTableDxe: copy XFirmwareCtl unconditionally

### DIFF
--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableProtocol.c
@@ -633,16 +633,13 @@ AddTableToList (
       //
       if ((UINT64)(UINTN)AcpiTableInstance->Facs3 < BASE_4GB) {
         AcpiTableInstance->Fadt3->FirmwareCtrl  = (UINT32) (UINTN) AcpiTableInstance->Facs3;
-        ZeroMem (&AcpiTableInstance->Fadt3->XFirmwareCtrl, sizeof (UINT64));
-      } else {
-        Buffer64 = (UINT64) (UINTN) AcpiTableInstance->Facs3;
-        CopyMem (
-          &AcpiTableInstance->Fadt3->XFirmwareCtrl,
-          &Buffer64,
-          sizeof (UINT64)
-          );
-        AcpiTableInstance->Fadt3->FirmwareCtrl = 0;
       }
+      Buffer64 = (UINT64) (UINTN) AcpiTableInstance->Facs3;
+      CopyMem (
+        &AcpiTableInstance->Fadt3->XFirmwareCtrl,
+        &Buffer64,
+        sizeof (UINT64)
+        );
       if ((UINT64)(UINTN)AcpiTableInstance->Dsdt3 < BASE_4GB) {
         AcpiTableInstance->Fadt3->Dsdt = (UINT32) (UINTN) AcpiTableInstance->Dsdt3;
         //
@@ -781,16 +778,13 @@ AddTableToList (
         //
         if ((UINT64)(UINTN)AcpiTableInstance->Facs3 < BASE_4GB) {
           AcpiTableInstance->Fadt3->FirmwareCtrl  = (UINT32) (UINTN) AcpiTableInstance->Facs3;
-          ZeroMem (&AcpiTableInstance->Fadt3->XFirmwareCtrl, sizeof (UINT64));
-        } else {
-          Buffer64 = (UINT64) (UINTN) AcpiTableInstance->Facs3;
-          CopyMem (
-            &AcpiTableInstance->Fadt3->XFirmwareCtrl,
-            &Buffer64,
-            sizeof (UINT64)
-            );
-          AcpiTableInstance->Fadt3->FirmwareCtrl = 0;
         }
+        Buffer64 = (UINT64) (UINTN) AcpiTableInstance->Facs3;
+        CopyMem (
+          &AcpiTableInstance->Fadt3->XFirmwareCtrl,
+          &Buffer64,
+          sizeof (UINT64)
+          );
 
         //
         // Checksum FADT table


### PR DESCRIPTION
Since coreboot commit https://github.com/Dasharo/coreboot/commit/a07b09ab71d04b870b9413b7e075a2369f59fd0a , coreboot looks for FACS at x_firmware_ctl when resuming from s3. EDK2 only allowed the 64 bit or 32 bit FACS address to be set at once and would zero out the other. This means that when FACS resides below 4G, x_firmware_ctl would be set zero and coreboot would fail to find the resume vector on wakeup from S3.

So just copy XFirmwareCtl from coreboot always.