### PR TITLE
UefiPayloadPkg: Use DxeRuntimeDebugLibSerialPort in DXE_RUNTIME_DRIVER

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -395,6 +395,8 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
   SmbusLib|MdePkg/Library/DxeSmbusLib/DxeSmbusLib.inf
   PerformanceLib|MdeModulePkg/Library/DxePerformanceLib/DxePerformanceLib.inf
+  DebugLib|MdePkg/Library/DxeRuntimeDebugLibSerialPort/DxeRuntimeDebugLibSerialPort.inf
+
 [LibraryClasses.common.UEFI_DRIVER,LibraryClasses.common.UEFI_APPLICATION]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf


### PR DESCRIPTION
Prevent debugging on serial port (whether physical or cbmem console) at runtime by using the DxeRuntimeDebugLibSerialPort library as DebugLib. It will stop calling SerialPortWrite if EFI switches to runtime and avoid access to cbmem CONSOLE buffer which is neither marked as runtime code nor data. Solves the issue with Xen backtrace on EFI reset system runtime service: https://github.com/Dasharo/dasharo-issues/issues/488#issuecomment-1772758851
