### PR TITLE
OvmfPkg/OvmfPkgX64.dsc: enable power state ofter power failure

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -570,6 +570,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowChipsetMenu|TRUE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPowerMenu|TRUE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowFanCurve|TRUE
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultPowerFailureState|0
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable|FALSE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise|TRUE
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions|TRUE


### PR DESCRIPTION
    This makes this option to appear in the Power menu, so it can
    be tested.
