### PR TITLE
SetupBrowserDxe/Setup.c: set browser action scope to system level

### DIFF
--- a/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Setup.c
@@ -53,7 +53,7 @@ BOOLEAN               gResetRequiredSystemLevel = FALSE;
 BOOLEAN               gExitRequired;
 BOOLEAN               gFlagReconnect;
 BOOLEAN               gCallbackReconnect;
-BROWSER_SETTING_SCOPE gBrowserSettingScope = FormSetLevel;
+BROWSER_SETTING_SCOPE gBrowserSettingScope = SystemLevel;
 BOOLEAN               mBrowserScopeFirstSet = TRUE;
 EXIT_HANDLER          ExitHandlerFunction = NULL;
 FORM_BROWSER_FORMSET  *mSystemLevelFormSet;


### PR DESCRIPTION
Set the browser action scope to system level to make the F9 (Reset to defaults) hotkey work globally. This also ensures F9 and F10 are always available and visible in the helptext at the bottom of the screen.

TEST=Boot on NovaCustom NV4x TGL, change some options in Dasharo System Features and Boot Maintenance Manager, then go to the User Password Management form and press F9 to reset to defaults. Verify that changes in Dasharo System Features and Boot Maintenance Manager are reverted.