### PR TITLE
SecureBootConfigDxe/SecureBootConfigImpl.c: add default for SB state

### DIFF
--- a/MdeModulePkg/Application/UiApp/FrontPageCustomizedUiSupport.c
+++ b/MdeModulePkg/Application/UiApp/FrontPageCustomizedUiSupport.c
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/MdeModuleHii.h>
 #include <Guid/GlobalVariable.h>
 
+#include <Protocol/FormBrowserEx.h>
 #include <Protocol/HiiConfigAccess.h>
 #include <Protocol/HiiString.h>
 
@@ -181,6 +182,7 @@ UiSupportLibCallbackHandler (
   OUT EFI_STATUS                             *Status
   )
 {
+  EDKII_FORM_BROWSER_EXTENSION_PROTOCOL *FormBrowserEx;
   if (QuestionId != FRONT_PAGE_KEY_CONTINUE &&
       QuestionId != FRONT_PAGE_KEY_RESET &&
       QuestionId != FRONT_PAGE_KEY_LANGUAGE) {
@@ -228,6 +230,10 @@ UiSupportLibCallbackHandler (
       //
       // Reset
       //
+      *Status = gBS->LocateProtocol (&gEdkiiFormBrowserExProtocolGuid, NULL, (VOID **) &FormBrowserEx);
+      if (!EFI_ERROR (Status))
+        FormBrowserEx->SaveReminder();
+
       gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
       *Status = EFI_UNSUPPORTED;
 

--- a/MdeModulePkg/Application/UiApp/UiApp.inf
+++ b/MdeModulePkg/Application/UiApp/UiApp.inf
@@ -62,6 +62,7 @@
 [Protocols]
   gEfiSmbiosProtocolGuid                        ## CONSUMES
   gEfiHiiConfigAccessProtocolGuid               ## CONSUMES
+  gEdkiiFormBrowserExProtocolGuid               ## CONSUMES
 
 [FeaturePcd]
 

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -5010,7 +5010,8 @@ SecureBootCallback (
       break;
     }
   } else if (Action == EFI_BROWSER_ACTION_DEFAULT_STANDARD) {
-    if (QuestionId == KEY_HIDE_SECURE_BOOT) {
+    switch (QuestionId) {
+    case KEY_HIDE_SECURE_BOOT: {
       GetVariable2 (EFI_PLATFORM_KEY_NAME, &gEfiGlobalVariableGuid, (VOID**)&Pk, NULL);
       if (Pk == NULL) {
         IfrNvData->HideSecureBoot = TRUE;
@@ -5019,6 +5020,22 @@ SecureBootCallback (
         IfrNvData->HideSecureBoot = FALSE;
       }
       Value->b = IfrNvData->HideSecureBoot;
+      break;
+    }
+    case KEY_SECURE_BOOT_ENABLE: {
+      Value->u8 = FixedPcdGet8 (PcdSecureBootDefaultEnable);
+      if (EFI_ERROR (SaveSecureBootVariable (Value->u8))) {
+        CreatePopUp (
+          EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE,
+          &Key,
+          L"Could not restore Secure Boot to default state!",
+          NULL
+          );
+      }
+      break;
+    }
+    default:
+      break;
     }
   } else if (Action == EFI_BROWSER_ACTION_FORM_CLOSE) {
     //


### PR DESCRIPTION
Fixes an issue where the setting would not be restored to the default value on pressing F9.