### PR TITLE
Pick up UEFI capsules from CBMEM

### DIFF
--- a/UefiPayloadPkg/BlSupportPei/BlSupportPei.c
+++ b/UefiPayloadPkg/BlSupportPei/BlSupportPei.c
@@ -752,6 +752,15 @@ BlPeiEntryPoint (
   }
 
   //
+  // Import update capsules, if there are any.
+  //
+  Status = ParseCapsules (BuildCvHob);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Error when importing update capsules, Status = %r\n", Status));
+    return Status;
+  }
+
+  //
   // Mask off all legacy 8259 interrupt sources
   //
   IoWrite8 (LEGACY_8259_MASK_REGISTER_MASTER, 0xFF);

--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -752,4 +752,13 @@ struct cb_tpm_physical_presence {
 	UINT8 ppi_version;	/* BCD encoded */
 };
 
+#define CB_TAG_CAPSULE  0x00b0
+
+struct cb_range {
+	UINT32 tag;
+	UINT32 size;
+	UINT64 range_start;
+	UINT32 range_size;
+} __attribute__((packed));
+
 #endif // _COREBOOT_PEI_H_INCLUDED_

--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -28,6 +28,9 @@
 typedef RETURN_STATUS \
         (*BL_MEM_INFO_CALLBACK) (MEMROY_MAP_ENTRY *MemoryMapEntry, VOID *Param);
 
+typedef VOID \
+        (*BL_CAPSULE_CALLBACK) (EFI_PHYSICAL_ADDRESS BaseAddress, UINT64 Length);
+
 /**
   This function retrieves the parameter base address from boot loader.
 
@@ -195,6 +198,20 @@ RETURN_STATUS
 EFIAPI
 ParseTimestampTable (
   OUT FIRMWARE_SEC_PERFORMANCE *Performance
+  );
+
+/**
+  Parse update capsules passed in by coreboot
+
+  @param  CapsuleCallback   The callback routine invoked for each capsule.
+
+  @retval RETURN_SUCCESS    Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND  coreboot table is missing.
+**/
+RETURN_STATUS
+EFIAPI
+ParseCapsules (
+  IN BL_CAPSULE_CALLBACK  CapsuleCallback
   );
 
 #endif

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -992,3 +992,39 @@ ParseTimestampTable (
   Performance->ResetEnd = DivU64x32(CbTsRec->base_time, CbTsRec->tick_freq_mhz);
   return RETURN_SUCCESS;
 }
+
+/**
+  Parse update capsules passed in by coreboot
+
+  @param  CapsuleCallback   The callback routine invoked for each capsule.
+
+  @retval RETURN_SUCCESS    Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND  coreboot table is missing.
+**/
+RETURN_STATUS
+EFIAPI
+ParseCapsules (
+  IN BL_CAPSULE_CALLBACK  CapsuleCallback
+  )
+{
+  struct cb_header  *Header;
+  struct cb_range   *Range;
+  UINT8             *TmpPtr;
+  UINTN             Idx;
+
+  Header = GetParameterBase ();
+  if (Header == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  TmpPtr = (UINT8 *)Header + Header->header_bytes;
+  for (Idx = 0; Idx < Header->table_entries; Idx++) {
+    Range = (struct cb_range *)TmpPtr;
+    if (Range->tag == CB_TAG_CAPSULE) {
+      CapsuleCallback (Range->range_start, Range->range_size);
+    }
+    TmpPtr += Range->size;
+  }
+
+  return RETURN_SUCCESS;
+}


### PR DESCRIPTION
Corresponding coreboot changes add a CBMEM entry per capsule, quite similar to PEI's HOBs.