### PR TITLE
DasharoPayloadPkg/GraphicsOutputDxe: Allow FB to be at offset from BAR

### DIFF
--- a/DasharoPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/DasharoPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -409,6 +409,10 @@ GraphicsOutputDriverBindingStart (
               if (Resources->AddrRangeMin == GraphicsInfo->FrameBufferBase) {
                 FrameBufferBase = Resources->AddrRangeMin;
                 break;
+              } else if (Resources->AddrRangeMin <= GraphicsInfo->FrameBufferBase
+                      && Resources->AddrRangeMin + Resources->AddrLen >= GraphicsInfo->FrameBufferBase + GraphicsInfo->FrameBufferSize ) {
+                FrameBufferBase = GraphicsInfo->FrameBufferBase;
+                break;
               }
             } else {
               break;

--- a/DasharoPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/DasharoPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -406,11 +406,8 @@ GraphicsOutputDriverBindingStart (
               FrameBufferBase = Resources->AddrRangeMin;
             }
             if (DeviceInfo->BarIndex == MAX_UINT8) {
-              if (Resources->AddrRangeMin == GraphicsInfo->FrameBufferBase) {
-                FrameBufferBase = Resources->AddrRangeMin;
-                break;
-              } else if (Resources->AddrRangeMin <= GraphicsInfo->FrameBufferBase
-                      && Resources->AddrRangeMin + Resources->AddrLen >= GraphicsInfo->FrameBufferBase + GraphicsInfo->FrameBufferSize ) {
+              if (Resources->AddrRangeMin <= GraphicsInfo->FrameBufferBase
+                  && Resources->AddrRangeMin + Resources->AddrLen >= GraphicsInfo->FrameBufferBase + GraphicsInfo->FrameBufferSize ) {
                 FrameBufferBase = GraphicsInfo->FrameBufferBase;
                 break;
               }


### PR DESCRIPTION
On MTL the framebuffer is at BAR2 + some offset. Allow for this case when validating the framebuffer info received from coreboot.

Same as https://github.com/Dasharo/edk2/pull/132 but for rebased edk2.