### PR TITLE
SecurityPkg/SecureBootConfigDxe: require reset on all SB changes

### DIFF
--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfig.vfr
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfig.vfr
@@ -266,7 +266,7 @@ formset
     goto FORMID_SECURE_BOOT_OPTION_FORM,
       prompt = STRING_TOKEN(STR_SAVE_AND_EXIT),
       help   = STRING_TOKEN(STR_SAVE_AND_EXIT),
-      flags  = INTERACTIVE,
+      flags  = INTERACTIVE | RESET_REQUIRED,
       key    = KEY_VALUE_SAVE_AND_EXIT_KEK;
 
     goto FORMID_SECURE_BOOT_OPTION_FORM,
@@ -470,7 +470,7 @@ formset
     goto FORMID_SECURE_BOOT_OPTION_FORM,
          prompt = STRING_TOKEN(STR_SAVE_AND_EXIT),
          help   = STRING_TOKEN(STR_SAVE_AND_EXIT),
-         flags  = INTERACTIVE,
+         flags  = INTERACTIVE | RESET_REQUIRED,
          key    = KEY_VALUE_SAVE_AND_EXIT_DB;
 
     goto FORMID_SECURE_BOOT_OPTION_FORM,
@@ -564,7 +564,7 @@ formset
     goto FORMID_SECURE_BOOT_OPTION_FORM,
          prompt = STRING_TOKEN(STR_SAVE_AND_EXIT),
          help   = STRING_TOKEN(STR_SAVE_AND_EXIT),
-         flags  = INTERACTIVE,
+         flags  = INTERACTIVE | RESET_REQUIRED,
          key    = KEY_VALUE_SAVE_AND_EXIT_DBX;
 
     goto FORMID_SECURE_BOOT_OPTION_FORM,
@@ -609,7 +609,7 @@ formset
     goto FORMID_SECURE_BOOT_OPTION_FORM,
          prompt = STRING_TOKEN(STR_SAVE_AND_EXIT),
          help   = STRING_TOKEN(STR_SAVE_AND_EXIT),
-         flags  = INTERACTIVE,
+         flags  = INTERACTIVE | RESET_REQUIRED,
          key    = KEY_VALUE_SAVE_AND_EXIT_DBT;
 
     goto FORMID_SECURE_BOOT_OPTION_FORM,

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -2514,7 +2514,7 @@ UpdateDeletePage (
         0,
         GuidID,
         Help,
-        EFI_IFR_FLAG_CALLBACK,
+        EFI_IFR_FLAG_CALLBACK | EFI_IFR_FLAG_RESET_REQUIRED,
         0,
         NULL
         );
@@ -3579,7 +3579,7 @@ LoadSignatureList (
     DstFormId,
     STRING_TOKEN (STR_SECURE_BOOT_DELETE_ALL_LIST),
     STRING_TOKEN (STR_SECURE_BOOT_DELETE_ALL_LIST),
-    EFI_IFR_FLAG_CALLBACK,
+    EFI_IFR_FLAG_CALLBACK | EFI_IFR_FLAG_RESET_REQUIRED,
     KEY_SECURE_BOOT_DELETE_ALL_LIST
   );
 
@@ -3651,7 +3651,7 @@ LoadSignatureList (
       SECUREBOOT_DELETE_SIGNATURE_DATA_FORM,
       HiiSetString (PrivateData->HiiHandle, 0, NameBuffer, NULL),
       HiiSetString (PrivateData->HiiHandle, 0, HelpBuffer, NULL),
-      EFI_IFR_FLAG_CALLBACK,
+      EFI_IFR_FLAG_CALLBACK | EFI_IFR_FLAG_RESET_REQUIRED,
       QuestionIdBase + Index++
     );
 


### PR DESCRIPTION
Enrolling or removing any signature should require a reset to avoid booting a system with some weird value of PCR-7.  The PCR is extended on writes into SecureBoot-related variables (see SecureBootHook() in SecurityPkg/DxeImageVerificationLib) and then right before booting (in TcgDxe or Tcg2Dxe in OnReadyToBoot() handler), meaning that editing SecureBoot configuration and continuing boot process without a reset results in an unexpected value of PCR-7 even if the end result of changes is the same as it would be without any changes.

Now reset is required in the following cases as well:
 * enrolling/deletion of a KEK signature
 * enrolling/deletion of a DB signature
 * enrolling/deletion of a DBX signature (one or all of them)
 * enrolling/deletion of a DBT signature

Addition cases are handled in VFR while deletion options are checkboxes generated in C and that's where the flags get set (number of updated places is fewer than number of handled cases because functions are shared by menus).