### PR TITLE
.gitmodules: use gerrit mirror for cmocka

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/ucb-bar/berkeley-softfloat-3.git
 [submodule "UnitTestFrameworkPkg/Library/CmockaLib/cmocka"]
 	path = UnitTestFrameworkPkg/Library/CmockaLib/cmocka
-	url = https://git.cryptomilk.org/projects/cmocka.git
+	url = https://review.coreboot.org/cmocka
 [submodule "DasharoModulePkg"]
 	path = DasharoModulePkg
 	url = https://github.com/Dasharo/DasharoModulePkg.git


### PR DESCRIPTION
https://git.cryptomilk.org/projects/cmocka.git/ failed to clone too many times during the last 2-3 weeks.