### PR TITLE
Serial issues fixes

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformConsole.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformConsole.c
@@ -329,9 +329,6 @@ PrepareLpcBridgeDevicePath (
     return Status;
   }
 
-  /* Start the drivers for all child devices of this controller/device */
-  gBS->ConnectController (DeviceHandle, NULL, NULL, TRUE);
-
   TempDevicePath = DevicePath;
 
   /* Don't bother with adding PS/2 keyboard if PS/2 not enabled in the project */


### PR DESCRIPTION
FIex the problem where the serial console redirection would be truly disabled after 2nd reset.


The BS->ConnectController was mainly added for external PS/2 Keyboard detection and input reliability. As external PS/2 is is not used in our lab on any board (laptops have the PS/2 always on), drop the ConnectController call. 