### PR TITLE
DasharoPayloadPkg: publish ESRT with an entry for coreboot

### DIFF
--- a/DasharoPayloadPkg/BlSupportDxe/BlSupportDxe.h
+++ b/DasharoPayloadPkg/BlSupportDxe/BlSupportDxe.h
@@ -17,17 +17,22 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DxeServicesTableLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/BlParseLib.h>
 #include <Library/UefiLib.h>
 #include <Library/IoLib.h>
 #include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
 
 #include <Guid/Acpi.h>
 #include <Guid/SmBios.h>
+#include <Guid/SystemResourceTable.h>
 #include <Guid/SystemTableInfoGuid.h>
 #include <Guid/AcpiBoardInfoGuid.h>
 #include <Guid/GraphicsInfoHob.h>
 
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/SmBios.h>
+
+#include <Coreboot.h>
 
 #endif

--- a/DasharoPayloadPkg/BlSupportDxe/BlSupportDxe.inf
+++ b/DasharoPayloadPkg/BlSupportDxe/BlSupportDxe.inf
@@ -40,6 +40,8 @@
   BaseMemoryLib
   UefiLib
   HobLib
+  BlParseLib
+  MemoryAllocationLib
 
 [Guids]
   gEfiAcpiTableGuid
@@ -47,6 +49,7 @@
   gUefiSystemTableInfoGuid
   gUefiAcpiBoardInfoGuid
   gEfiGraphicsInfoHobGuid
+  gEfiSystemResourceTableGuid
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution

--- a/DasharoPayloadPkg/Include/Coreboot.h
+++ b/DasharoPayloadPkg/Include/Coreboot.h
@@ -762,4 +762,25 @@ struct cb_range {
 	UINT32 range_size;
 } __attribute__((packed));
 
+#define CB_TAG_FW_INFO  0x0045
+
+/*
+ * Machine-friendly version of a system firmware component.  A component is
+ * identified by a GUID.  coreboot is an obvious main component but there could
+ * be others (like EC) which should get their own instances of the tag.
+ *
+ * The main consumer of this information is UEFI firmware but something else
+ * could reuse it too.
+ *
+ * Larger number in a version field corresponds to a more recent version.
+ */
+struct lb_efi_fw_info {
+  UINT32 tag;
+  UINT32 size;
+  UINT8 guid[16];                   /* Called "firmware class" in UEFI */
+  UINT32 version;                   /* Current version */
+  UINT32 lowest_supported_version;  /* Lowest allowed version */
+  UINT32 fw_size;                   /* Size of firmware in bytes */
+} __attribute__ ((packed));
+
 #endif // _COREBOOT_PEI_H_INCLUDED_

--- a/DasharoPayloadPkg/Include/Coreboot.h
+++ b/DasharoPayloadPkg/Include/Coreboot.h
@@ -753,7 +753,7 @@ struct cb_tpm_physical_presence {
 	UINT8 ppi_version;	/* BCD encoded */
 };
 
-#define CB_TAG_CAPSULE  0x00b0
+#define CB_TAG_CAPSULE  0x0046
 
 struct cb_range {
 	UINT32 tag;

--- a/DasharoPayloadPkg/Include/Library/BlParseLib.h
+++ b/DasharoPayloadPkg/Include/Library/BlParseLib.h
@@ -212,4 +212,25 @@ ParseBootLogo (
   OUT UINT32 *BmpSize
   );
 
+/**
+  Parse firmware information passed in by coreboot
+
+  @param  Guid     Kind of the firmware.
+  @param  Version  Current version.
+  @param  Lsv      Lowest supported version.
+  @param  Size     Firmware size in bytes.
+
+  @retval RETURN_INVALID_PARAMETER  At least one of the parameters is NULL.
+  @retval RETURN_SUCCESS            Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND          coreboot table is missing.
+**/
+RETURN_STATUS
+EFIAPI
+ParseFwInfo (
+  OUT EFI_GUID  *Guid,
+  OUT UINT32    *Version,
+  OUT UINT32    *Lsv,
+  OUT UINT32    *Size
+  );
+
 #endif

--- a/DasharoPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/DasharoPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -1024,3 +1024,42 @@ ParseBootLogo (
 
   return RETURN_SUCCESS;
 }
+
+/**
+  Parse firmware information passed in by coreboot
+
+  @param  Guid     Kind of the firmware.
+  @param  Version  Current version.
+  @param  Lsv      Lowest supported version.
+  @param  Size     Firmware size in bytes.
+
+  @retval RETURN_INVALID_PARAMETER  At least one of the parameters is NULL.
+  @retval RETURN_SUCCESS            Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND          coreboot table is missing.
+**/
+RETURN_STATUS
+EFIAPI
+ParseFwInfo (
+  OUT EFI_GUID  *Guid,
+  OUT UINT32    *Version,
+  OUT UINT32    *Lsv,
+  OUT UINT32    *Size
+  )
+{
+  struct lb_efi_fw_info  *FwInfo;
+
+  if (Guid == NULL || Version == NULL || Lsv == NULL || Size == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  FwInfo = FindCbTag (CB_TAG_FW_INFO);
+  if (FwInfo == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  CopyMem (Guid, &FwInfo->guid, sizeof (*Guid));
+  *Version = FwInfo->version;
+  *Lsv = FwInfo->lowest_supported_version;
+  *Size = FwInfo->fw_size;
+  return RETURN_SUCCESS;
+}


### PR DESCRIPTION
CbParseLib implementation of BlParseLib was extended to allow querying CB_TAG_FW_INFO tag from coreboot table.

And BlSupportDxe was made to use this information to publish a single-element ESRT.  Later on ESRT will likely be constructed by EsrtFmpDxe from data provided by FMP instances, but until then this should be good enough for viewing this information in an OS.

coreboot part: https://github.com/Dasharo/coreboot/pull/527