### PR TITLE
AuthVariableLib: Set SB to enabled during transition to USER_MODE

### DIFF
--- a/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.c
@@ -205,9 +205,13 @@ AuthVariableLibInitialize (
     }
   } else if (mPlatformMode == USER_MODE) {
     //
-    // "SecureBootEnable" not exist, initialize it in USER_MODE.
+    // "SecureBootEnable" not exist, initialize it in USER_MODE. Can't use
+    // PcdSecureBootDefaultEnable here, because it will prevent enabling
+    // Secure Boot from OS when transitioning from SETUP_MODE to USER_MODE.
+    // PcdSecureBootDefaultEnable is used when settings are reset in UI and in
+    // the SecureBootDefaultKeysDxe where the default keys are being restored.
     //
-    SecureBootEnable = FixedPcdGet8 (PcdSecureBootDefaultEnable);
+    SecureBootEnable = SECURE_BOOT_ENABLE;
     Status = AuthServiceInternalUpdateVariable (
                EFI_SECURE_BOOT_ENABLE_NAME,
                &gEfiSecureBootEnableDisableGuid,


### PR DESCRIPTION
When the system is booted, the AuthVariableLibInitialize runs before SecureBootDefaultKeysDxe. When the system is booted for the first time, AuthVariableLibInitialize will not set SB to enabled state, because there are no keys yet. So the SecureBootEnable does not need to be set depending on PCD, even shouldn't. It is the SecureBootDefaultKeysDxe task to set the proper SB state when system boots with default settings. The PCD is still used there and in the UI when restoring default settings.

Quick tests:

 When SB Default State PCD is `FALSE`:
 1. Secure Boot state on first boot (SMMSTORE region empty) - Disabled - PASS
 2. Secure Boot state when defaults are restored with F9 in UI - Disabled - PASS
     - enter SB menu and enable SB, reboot
     - enter SB menu and press F9, save and reboot
     - enter SB menu and confirm the SB state to be equal to the PCD value
 3. Secure Boot state when keys are enrolled from OS - Enabled - PASS
    - enter SB menu and erase all keys, reboot
    - boot Ubuntu and provision keys, e.g. http://jk.ozlabs.org/docs/sbkeysync-maintaing-uefi-key-databases/
    - reboot to setup UI and confirm SB state
 4. Booting Ubuntu with SB:
    - Booting standard shim+grub - Access Denied - PASS
    - Booting custom signed grub - PASS (but did not boot OS due to shim_lock protocol not found, kind of expected when shim was omitted)
 
 When SB Default State PCD is `TRUE`:
 1. Secure Boot state on first boot (SMMSTORE region empty) - Enabled - PASS
 2. Secure Boot state when defaults are restored with F9 in UI - Enabled - PASS
     - enter SB menu and disable SB, reboot
     - enter SB menu and press F9, save and reboot
     - enter SB menu and confirm the SB state to be equal to the PCD value
 3. Secure Boot state when keys are enrolled from OS - Enabled - PASS
    - enter SB menu and erase all keys, reboot
    - boot Ubuntu and provision keys, e.g. http://jk.ozlabs.org/docs/sbkeysync-maintaing-uefi-key-databases/
    - reboot to setup UI and confirm SB state
 4. Booting Ubuntu with SB:
    - Booting standard shim+grub - Access Denied - PASS
    - Booting custom signed grub - PASS (but did not boot OS due to shim_lock protocol not found, kind of expected when shim was omitted)
  
Questions:

1. ~~Resetting Secure Boot keys to defaults causes the SB state to become enabled, but it can also set the state to disabled if we want to. Is it the behavior we want?~~ Done, now when resetting the keys, Enable Secure Boot checkbox remains unchanged. Only the Current Secure Boot State changes from Disabled to Enabled, but there is now way around it. SecureBoot variable becomes locked after enrolling PK.
2. Pressing F9 in SB menu restores the Secure Boot enable state only to the PCD value, it does not restore the keys to defaults, but it could if we want to. Is it the behavior we want?

