### PR TITLE
Implement capsule flashing via extended SMMSTORE v2

### DIFF
--- a/DasharoModulePkg/Include/Library/DasharoVariablesLib.h
+++ b/DasharoModulePkg/Include/Library/DasharoVariablesLib.h
@@ -63,4 +63,17 @@ DasharoEnableFUM (
   VOID
   );
 
+/**
+  Check whether capsule updates which survive a warm system reset are permitted
+  by current configuration.
+
+  @retval TRUE   Persistent capsules can be accepted by UpdateCapsule().
+  @retval FALSE  UpdateCapsule() must fail with an error for such a capsule.
+**/
+BOOLEAN
+EFIAPI
+DasharoCapsulesCanPersistAcrossReset (
+  VOID
+  );
+
 #endif

--- a/DasharoModulePkg/Include/Library/DasharoVariablesLib.h
+++ b/DasharoModulePkg/Include/Library/DasharoVariablesLib.h
@@ -52,4 +52,15 @@ DasharoMeasureVariables (
   VOID
   );
 
+/**
+  Enable firmware update mode (FUM) for the duration of the next boot.
+
+  @retval RETURN_SUCCESS  FUM was successfully enabled.
+**/
+EFI_STATUS
+EFIAPI
+DasharoEnableFUM (
+  VOID
+  );
+
 #endif

--- a/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -618,9 +618,7 @@ DasharoSystemFeaturesCallback (
 {
   EFI_STATUS                                 Status;
   EFI_INPUT_KEY                              Key;
-  BOOLEAN                                    Enable;
 
-  Enable = TRUE;
   Status = EFI_SUCCESS;
 
   switch (Action) {
@@ -701,13 +699,7 @@ DasharoSystemFeaturesCallback (
         } while ((Key.ScanCode != SCAN_ESC) && (Key.UnicodeChar != CHAR_CARRIAGE_RETURN));
 
         if (Key.UnicodeChar == CHAR_CARRIAGE_RETURN) {
-          Status = gRT->SetVariable (
-              DASHARO_VAR_FIRMWARE_UPDATE_MODE,
-              &gDasharoSystemFeaturesGuid,
-              EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-              sizeof (Enable),
-              &Enable
-              );
+          Status = DasharoEnableFUM ();
           if (EFI_ERROR (Status)) {
             return Status;
           }

--- a/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -65,6 +65,8 @@
 #string STR_DASHARO_INTEL_ME_OPTIONS_TITLE   #language en-US  "Intel Management Engine Options"
 #string STR_DASHARO_INTEL_ME_OPTIONS_HELP    #language en-US  "Configuration for Intel Management Engine"
 
+#string STR_CAPSULE_UPDATE_MSG   #language en-US  "Setting 'Intel ME mode' to 'Disabled (HAP)' allows updating system firmware via a UEFI capsule."
+
 #string STR_ME_MODE_PROMPT   #language en-US  "Intel ME mode"
 #string STR_ME_MODE_HELP     #language en-US  "Operation mode of the Intel Management Engine. The ME can be enabled, or disabled using various methods.\n\n"
                                                 "Enabled: Enable the Intel Management Engine.\n\n"

--- a/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -218,6 +218,9 @@ formset
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
 
     disableif ideqval FeaturesData.ShowIntelMeMenu == 0;
+      disableif ideqval FeaturesData.MeHapAvailable == 0;
+        subtitle text = STRING_TOKEN(STR_CAPSULE_UPDATE_MSG);
+      endif;
       oneof varid  = FeaturesData.MeMode,
             questionid = INTEL_ME_MODE_QUESTION_ID,
             prompt = STRING_TOKEN(STR_ME_MODE_PROMPT),

--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -439,6 +439,64 @@ DasharoEnableFUM (
   return Status;
 }
 
+/**
+  Check whether capsule updates which survive a warm system reset are permitted
+  by current configuration.
+
+  @retval TRUE   Persistent capsules can be accepted by UpdateCapsule().
+  @retval FALSE  UpdateCapsule() must fail with an error for such a capsule.
+**/
+BOOLEAN
+EFIAPI
+DasharoCapsulesCanPersistAcrossReset (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       MeMode;
+  UINTN       VarSize;
+
+  //
+  // Assuming there is no ME if the corresponding menu is not enabled.
+  //
+  if (!FixedPcdGetBool (PcdShowIntelMeMenu)) {
+    return TRUE;
+  }
+
+  //
+  // Guard against variable's value obviously lying about the state.
+  //
+  if (!FixedPcdGetBool (PcdIntelMeHapAvailable)) {
+    return FALSE;
+  }
+
+  MeMode = DASHARO_ME_MODE_ENABLE;
+  VarSize = sizeof (MeMode);
+
+  Status = gRT->GetVariable (
+      DASHARO_VAR_ME_MODE,
+      &gDasharoSystemFeaturesGuid,
+      NULL,
+      &VarSize,
+      &MeMode
+      );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // HAP-disabled ME doesn't do anything, including writing to system flash,
+  // which is what we need for a firmware update that relies on a warm reset.
+  // coreboot assumes that HECI/soft-disabled state of ME isn't as good as
+  // HMRFPO and switches to HMRFPO doing a global reset which loses in-RAM
+  // capsules.
+  //
+  // Checking variable's value should be enough, if somebody manually set it to
+  // an invalid value, the update there will be a reboot without a capsule
+  // update.  A more reliable solution would be to pass this information from
+  // coreboot.
+  //
+  return MeMode == DASHARO_ME_MODE_DISABLE_HAP;
+}
+
 EFI_STATUS
 EFIAPI
 DasharoVariablesLibConstructor (

--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -413,6 +413,32 @@ DasharoMeasureVariables (
   return Status;
 }
 
+/**
+  Enable firmware update mode (FUM) for the next boot.
+
+  @retval RETURN_SUCCESS  FUM was successfully enabled.
+**/
+EFI_STATUS
+EFIAPI
+DasharoEnableFUM (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  BOOLEAN     Enable;
+
+  Enable = TRUE;
+  Status = gRT->SetVariable (
+      DASHARO_VAR_FIRMWARE_UPDATE_MODE,
+      &gDasharoSystemFeaturesGuid,
+      EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+      sizeof (Enable),
+      &Enable
+      );
+
+  return Status;
+}
+
 EFI_STATUS
 EFIAPI
 DasharoVariablesLibConstructor (

--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -14,7 +14,7 @@
   FILE_GUID                      = F7C51973-0F61-4955-87D2-710FD578D161
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DasharoVariablesLib|DXE_DRIVER UEFI_APPLICATION
+  LIBRARY_CLASS                  = DasharoVariablesLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION
   CONSTRUCTOR                    = DasharoVariablesLibConstructor
 
 #

--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -67,6 +67,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowWiFiBtOption
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowCameraOption
   gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeDefaultState
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeHapAvailable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowLockBios
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowSmmBwp
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPs2Option

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -234,8 +234,7 @@
   # No need to save/restore FMP dependencies until they are utilized
   FmpDependencyDeviceLib|FmpDevicePkg/Library/FmpDependencyDeviceLibNull/FmpDependencyDeviceLibNull.inf
   FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
-  # TODO: provide real implementation of firmware flashing
-  FmpDeviceLib|FmpDevicePkg/Library/FmpDeviceLibNull/FmpDeviceLibNull.inf
+  FmpDeviceLib|DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
   FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
 !else
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf

--- a/DasharoPayloadPkg/Include/Library/BlParseLib.h
+++ b/DasharoPayloadPkg/Include/Library/BlParseLib.h
@@ -233,4 +233,18 @@ ParseFwInfo (
   OUT UINT32    *Size
   );
 
+/**
+  Parse information in a string form identified by a number
+
+  @param  Id  String identifier.
+
+  @retval NULL       The requested information wasn't found.
+  @retval Otherwise  A pointer to a static string.
+**/
+CONST CHAR8 *
+EFIAPI
+ParseInfoString (
+  IN UINTN  Id
+  );
+
 #endif

--- a/DasharoPayloadPkg/Include/Library/SmmStoreLib.h
+++ b/DasharoPayloadPkg/Include/Library/SmmStoreLib.h
@@ -96,6 +96,16 @@ SmmStoreLibEraseBlock (
   );
 
 /**
+  Function to update a pointer on virtual address change.  Matches the signature
+  and operation of EfiConvertPointer.
+
+**/
+typedef EFI_STATUS EFIAPI (*ConvertPointerFunc) (
+  IN UINTN     DebugDisposition,
+  IN OUT VOID  **Address
+  );
+
+/**
   Initializes SmmStore support
 
   @retval EFI_WRITE_PROTECTED   The SmmStore is not present.
@@ -106,6 +116,21 @@ SmmStoreLibEraseBlock (
 EFI_STATUS
 SmmStoreLibInitialize (
   VOID
+  );
+
+/**
+  Fixup internal data so that EFI can be called in virtual mode.
+  Converts any pointers in lib to virtual mode. This function is meant to
+  be invoked on gEfiEventVirtualAddressChangeGuid event when the library is
+  used at run-time.
+
+  @param[in] ConvertPointer  Function to switch virtual address space.
+
+**/
+VOID
+EFIAPI
+SmmStoreLibVirtualAddressChange (
+  IN ConvertPointerFunc  ConvertPointer
   );
 
 /**

--- a/DasharoPayloadPkg/Include/Library/SmmStoreLib.h
+++ b/DasharoPayloadPkg/Include/Library/SmmStoreLib.h
@@ -1,6 +1,7 @@
 /** @file  SmmStoreLib.h
 
   Copyright (c) 2022, 9elements GmbH<BR>
+  Copyright (c) 2024, 3mdeb Sp. z o.o.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -67,6 +68,25 @@ SmmStoreLibRead (
   );
 
 /**
+  Read from an arbitrary flash location.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param[in] Lba      The starting logical block index to read from.
+  @param[in] Offset   Offset into the block at which to begin reading.
+  @param[in] NumBytes On input, indicates the requested read size. On
+                      output, indicates the actual number of bytes read
+  @param[in] Buffer   Pointer to the buffer to read into.
+
+**/
+EFI_STATUS
+SmmStoreLibReadAnyBlock (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  );
+
+/**
   Write to SmmStore
 
   @param[in] Lba      The starting logical block index to write to.
@@ -85,6 +105,25 @@ SmmStoreLibWrite (
   );
 
 /**
+  Write to an arbitrary flash location.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param[in] Lba      The starting logical block index to write to.
+  @param[in] Offset   Offset into the block at which to begin writing.
+  @param[in] NumBytes On input, indicates the requested write size. On
+                      output, indicates the actual number of bytes written
+  @param[in] Buffer   Pointer to the data to write.
+
+**/
+EFI_STATUS
+SmmStoreLibWriteAnyBlock (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  );
+
+/**
   Erase a block using the SmmStore
 
   @param Lba    The logical block index to erase.
@@ -96,7 +135,19 @@ SmmStoreLibEraseBlock (
   );
 
 /**
-  Function to update a pointer on virtual address change.  Matches the signature
+  Erase an arbitrary block of the flash.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param Lba    The logical block index to erase.
+
+**/
+EFI_STATUS
+SmmStoreLibEraseAnyBlock (
+  IN         EFI_LBA  Lba
+  );
+
+/**
+  Function to update a pointer on virtual address change. Matches the signature
   and operation of EfiConvertPointer.
 
 **/

--- a/DasharoPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/DasharoPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -1063,3 +1063,27 @@ ParseFwInfo (
   *Size = FwInfo->fw_size;
   return RETURN_SUCCESS;
 }
+
+/**
+  Parse information in a string form identified by a number
+
+  @param  Id  String identifier.
+
+  @retval NULL       The requested information wasn't found.
+  @retval Otherwise  A pointer to a static string.
+**/
+CONST CHAR8 *
+EFIAPI
+ParseInfoString (
+  IN UINTN  Id
+  )
+{
+  struct cb_string  *CbString;
+
+  CbString = FindCbTag (Id);
+  if (CbString == NULL) {
+    return NULL;
+  }
+
+  return (CONST CHAR8 *)CbString->string;
+}

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -1,0 +1,1089 @@
+/** @file
+  Provides firmware device specific services to support updates of a firmware
+  image stored in a firmware device.
+
+  Copyright (c) Microsoft Corporation.<BR>
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+#include <Guid/SystemResourceTable.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/FmpDeviceLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PrintLib.h>
+#include <Library/SmmStoreLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Coreboot.h>
+
+typedef struct {
+  EFI_GUID  FwGuid;
+  UINT32    FwVersion;
+  UINT32    FwLsv;
+  UINT32    FwSize;
+} FwInfo;
+
+/**
+  This function requests firmware information on the first call, caches it and
+  return on all calls afterwards.
+
+  @param[out] Info  Place to store a pointer to firmware information.
+
+  @retval EFI_SUCCESS            Info points to firmware information.
+  @retval EFI_INVALID_PARAMETER  Info is NULL.
+**/
+STATIC
+EFI_STATUS
+GetFwInfo (
+  OUT FwInfo  **Info
+  )
+{
+  STATIC FwInfo   Storage;
+  STATIC BOOLEAN  Initialized;
+
+  EFI_STATUS  Status;
+
+  if (Info == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!Initialized) {
+    Status = ParseFwInfo (&Storage.FwGuid, &Storage.FwVersion, &Storage.FwLsv, &Storage.FwSize);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a(): ParseFwInfo() failed with: %r\n", __FUNCTION__, Status));
+      return Status;
+    }
+
+    Initialized = TRUE;
+  }
+
+  *Info = &Storage;
+  return EFI_SUCCESS;
+}
+
+/**
+  Provide a function to install the Firmware Management Protocol instance onto a
+  device handle when the device is managed by a driver that follows the UEFI
+  Driver Model.  If the device is not managed by a driver that follows the UEFI
+  Driver Model, then EFI_UNSUPPORTED is returned.
+
+  @param[in] FmpInstaller  Function that installs the Firmware Management
+                           Protocol.
+
+  @retval EFI_SUCCESS      The device is managed by a driver that follows the
+                           UEFI Driver Model.  FmpInstaller must be called on
+                           each Driver Binding Start().
+  @retval EFI_UNSUPPORTED  The device is not managed by a driver that follows
+                           the UEFI Driver Model.
+  @retval other            The Firmware Management Protocol for this firmware
+                           device is not installed.  The firmware device is
+                           still locked using FmpDeviceLock().
+**/
+EFI_STATUS
+EFIAPI
+RegisterFmpInstaller (
+  IN FMP_DEVICE_LIB_REGISTER_FMP_INSTALLER  Function
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Provide a function to uninstall the Firmware Management Protocol instance from a
+  device handle when the device is managed by a driver that follows the UEFI
+  Driver Model.  If the device is not managed by a driver that follows the UEFI
+  Driver Model, then EFI_UNSUPPORTED is returned.
+
+  @param[in] FmpUninstaller  Function that installs the Firmware Management
+                             Protocol.
+
+  @retval EFI_SUCCESS      The device is managed by a driver that follows the
+                           UEFI Driver Model.  FmpUninstaller must be called on
+                           each Driver Binding Stop().
+  @retval EFI_UNSUPPORTED  The device is not managed by a driver that follows
+                           the UEFI Driver Model.
+  @retval other            The Firmware Management Protocol for this firmware
+                           device is not installed.  The firmware device is
+                           still locked using FmpDeviceLock().
+**/
+EFI_STATUS
+EFIAPI
+RegisterFmpUninstaller (
+  IN FMP_DEVICE_LIB_REGISTER_FMP_UNINSTALLER  Function
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Set the device context for the FmpDeviceLib services when the device is
+  managed by a driver that follows the UEFI Driver Model.  If the device is not
+  managed by a driver that follows the UEFI Driver Model, then EFI_UNSUPPORTED
+  is returned.  Once a device context is set, the FmpDeviceLib services
+  operate on the currently set device context.
+
+  @param[in]      Handle   Device handle for the FmpDeviceLib services.
+                           If Handle is NULL, then Context is freed.
+  @param[in, out] Context  Device context for the FmpDeviceLib services.
+                           If Context is NULL, then a new context is allocated
+                           for Handle and the current device context is set and
+                           returned in Context.  If Context is not NULL, then
+                           the current device context is set.
+
+  @retval EFI_SUCCESS      The device is managed by a driver that follows the
+                           UEFI Driver Model.
+  @retval EFI_UNSUPPORTED  The device is not managed by a driver that follows
+                           the UEFI Driver Model.
+  @retval other            The Firmware Management Protocol for this firmware
+                           device is not installed.  The firmware device is
+                           still locked using FmpDeviceLock().
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSetContext (
+  IN EFI_HANDLE  Handle,
+  IN OUT VOID    **Context
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Returns the size, in bytes, of the firmware image currently stored in the
+  firmware device.  This function is used to by the GetImage() and
+  GetImageInfo() services of the Firmware Management Protocol.  If the image
+  size can not be determined from the firmware device, then 0 must be returned.
+
+  @param[out] Size  Pointer to the size, in bytes, of the firmware image
+                    currently stored in the firmware device.
+
+  @retval EFI_SUCCESS            The size of the firmware image currently
+                                 stored in the firmware device was returned.
+  @retval EFI_INVALID_PARAMETER  Size is NULL.
+  @retval EFI_UNSUPPORTED        The firmware device does not support reporting
+                                 the size of the currently stored firmware image.
+  @retval EFI_DEVICE_ERROR       An error occurred attempting to determine the
+                                 size of the firmware image currently stored in
+                                 in the firmware device.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetSize (
+  OUT UINTN  *Size
+  )
+{
+  EFI_STATUS  Status;
+  FwInfo      *FwInfo;
+
+  if (Size == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *Size = FwInfo->FwSize;
+  }
+  return Status;
+}
+
+/**
+  Returns the GUID value used to fill in the ImageTypeId field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_UNSUPPORTED is returned,
+  then the ImageTypeId field is set to gEfiCallerIdGuid.  If EFI_SUCCESS is
+  returned, then ImageTypeId is set to the Guid returned from this function.
+
+  @param[out] Guid  Double pointer to a GUID value that is updated to point to
+                    to a GUID value.  The GUID value is not allocated and must
+                    not be modified or freed by the caller.
+
+  @retval EFI_SUCCESS      EFI_FIRMWARE_IMAGE_DESCRIPTOR ImageTypeId GUID is set
+                           to the returned Guid value.
+  @retval EFI_UNSUPPORTED  EFI_FIRMWARE_IMAGE_DESCRIPTOR ImageTypeId GUID is set
+                           to gEfiCallerIdGuid.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetImageTypeIdGuidPtr (
+  OUT EFI_GUID  **Guid
+  )
+{
+  EFI_STATUS  Status;
+  FwInfo      *FwInfo;
+
+  if (Guid == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *Guid = &FwInfo->FwGuid;
+  }
+  return Status;
+}
+
+/**
+  Returns values used to fill in the AttributesSupported and AttributesSettings
+  fields of the EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the
+  GetImageInfo() service of the Firmware Management Protocol.  The following
+  bit values from the Firmware Management Protocol may be combined:
+    IMAGE_ATTRIBUTE_IMAGE_UPDATABLE
+    IMAGE_ATTRIBUTE_RESET_REQUIRED
+    IMAGE_ATTRIBUTE_AUTHENTICATION_REQUIRED
+    IMAGE_ATTRIBUTE_IN_USE
+    IMAGE_ATTRIBUTE_UEFI_IMAGE
+
+  @param[out] Supported  Attributes supported by this firmware device.
+  @param[out] Setting    Attributes settings for this firmware device.
+
+  @retval EFI_SUCCESS            The attributes supported by the firmware
+                                 device were returned.
+  @retval EFI_INVALID_PARAMETER  Supported is NULL.
+  @retval EFI_INVALID_PARAMETER  Setting is NULL.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetAttributes (
+  OUT UINT64  *Supported,
+  OUT UINT64  *Setting
+  )
+{
+  if (Supported == NULL || Setting == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Supported = IMAGE_ATTRIBUTE_IMAGE_UPDATABLE
+             | IMAGE_ATTRIBUTE_RESET_REQUIRED
+             | IMAGE_ATTRIBUTE_AUTHENTICATION_REQUIRED
+             | IMAGE_ATTRIBUTE_IN_USE;
+  *Setting   = *Supported;
+  return EFI_SUCCESS;
+}
+
+/**
+  Returns the value used to fill in the LowestSupportedVersion field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_SUCCESS is returned, then
+  the firmware device supports a method to report the LowestSupportedVersion
+  value from the currently stored firmware image.  If the value can not be
+  reported for the firmware image currently stored in the firmware device, then
+  EFI_UNSUPPORTED must be returned.  EFI_DEVICE_ERROR is returned if an error
+  occurs attempting to retrieve the LowestSupportedVersion value for the
+  currently stored firmware image.
+
+  @note It is recommended that all firmware devices support a method to report
+        the LowestSupportedVersion value from the currently stored firmware
+        image.
+
+  @param[out] LowestSupportedVersion  LowestSupportedVersion value retrieved
+                                      from the currently stored firmware image.
+
+  @retval EFI_SUCCESS       The lowest supported version of currently stored
+                            firmware image was returned in LowestSupportedVersion.
+  @retval EFI_UNSUPPORTED   The firmware device does not support a method to
+                            report the lowest supported version of the currently
+                            stored firmware image.
+  @retval EFI_DEVICE_ERROR  An error occurred attempting to retrieve the lowest
+                            supported version of the currently stored firmware
+                            image.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetLowestSupportedVersion (
+  OUT UINT32  *LowestSupportedVersion
+  )
+{
+  EFI_STATUS  Status;
+  FwInfo      *FwInfo;
+
+  if (LowestSupportedVersion == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *LowestSupportedVersion = FwInfo->FwLsv;
+  }
+  return Status;
+}
+
+/**
+  Returns the Null-terminated Unicode string that is used to fill in the
+  VersionName field of the EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is
+  returned by the GetImageInfo() service of the Firmware Management Protocol.
+  The returned string must be allocated using EFI_BOOT_SERVICES.AllocatePool().
+
+  @note It is recommended that all firmware devices support a method to report
+        the VersionName string from the currently stored firmware image.
+
+  @param[out] VersionString  The version string retrieved from the currently
+                             stored firmware image.
+
+  @retval EFI_SUCCESS            The version string of currently stored
+                                 firmware image was returned in Version.
+  @retval EFI_INVALID_PARAMETER  VersionString is NULL.
+  @retval EFI_UNSUPPORTED        The firmware device does not support a method
+                                 to report the version string of the currently
+                                 stored firmware image.
+  @retval EFI_DEVICE_ERROR       An error occurred attempting to retrieve the
+                                 version string of the currently stored
+                                 firmware image.
+  @retval EFI_OUT_OF_RESOURCES   There are not enough resources to allocate the
+                                 buffer for the version string of the currently
+                                 stored firmware image.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetVersionString (
+  OUT CHAR16  **VersionString
+  )
+{
+  CONST CHAR8  *CbVersion;
+  CONST CHAR8  *CbExtraVersion;
+  UINTN        Size;
+
+  if (VersionString == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CbVersion = ParseInfoString (CB_TAG_VERSION);
+  CbExtraVersion = ParseInfoString (CB_TAG_EXTRA_VERSION);
+
+  if (CbVersion == NULL) {
+    CbVersion = "";
+  }
+
+  if (CbExtraVersion == NULL) {
+    CbExtraVersion = "";
+  }
+
+  Size = (AsciiStrLen (CbVersion) + AsciiStrLen (CbExtraVersion) + 1) * sizeof (CHAR16);
+  *VersionString = AllocatePool (Size);
+  if (*VersionString == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  UnicodeSPrint (*VersionString, Size, L"%a%a", CbVersion, CbExtraVersion);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Returns the value used to fill in the Version field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_SUCCESS is returned, then
+  the firmware device supports a method to report the Version value from the
+  currently stored firmware image.  If the value can not be reported for the
+  firmware image currently stored in the firmware device, then EFI_UNSUPPORTED
+  must be returned.  EFI_DEVICE_ERROR is returned if an error occurs attempting
+  to retrieve the LowestSupportedVersion value for the currently stored firmware
+  image.
+
+  @note It is recommended that all firmware devices support a method to report
+        the Version value from the currently stored firmware image.
+
+  @param[out] Version  The version value retrieved from the currently stored
+                       firmware image.
+
+  @retval EFI_SUCCESS       The version of currently stored firmware image was
+                            returned in Version.
+  @retval EFI_UNSUPPORTED   The firmware device does not support a method to
+                            report the version of the currently stored firmware
+                            image.
+  @retval EFI_DEVICE_ERROR  An error occurred attempting to retrieve the version
+                            of the currently stored firmware image.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetVersion (
+  OUT UINT32  *Version
+  )
+{
+  EFI_STATUS  Status;
+  FwInfo      *FwInfo;
+
+  if (Version == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *Version = FwInfo->FwVersion;
+  }
+  return Status;
+}
+
+/**
+  Returns the value used to fill in the HardwareInstance field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_SUCCESS is returned, then
+  the firmware device supports a method to report the HardwareInstance value.
+  If the value can not be reported for the firmware device, then EFI_UNSUPPORTED
+  must be returned.  EFI_DEVICE_ERROR is returned if an error occurs attempting
+  to retrieve the HardwareInstance value for the firmware device.
+
+  @param[out] HardwareInstance  The hardware instance value for the firmware
+                                device.
+
+  @retval EFI_SUCCESS       The hardware instance for the current firmware
+                            device is returned in HardwareInstance.
+  @retval EFI_UNSUPPORTED   The firmware device does not support a method to
+                            report the hardware instance value.
+  @retval EFI_DEVICE_ERROR  An error occurred attempting to retrieve the hardware
+                            instance value.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetHardwareInstance (
+  OUT UINT64  *HardwareInstance
+  )
+{
+  if (HardwareInstance == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *HardwareInstance = 0;
+  return EFI_SUCCESS;
+}
+
+/**
+  Returns a copy of the firmware image currently stored in the firmware device.
+
+  @note It is recommended that all firmware devices support a method to retrieve
+        a copy currently stored firmware image.  This can be used to support
+        features such as recovery and rollback.
+
+  @param[out]     Image     Pointer to a caller allocated buffer where the
+                            currently stored firmware image is copied to.
+  @param[in, out] ImageSize Pointer the size, in bytes, of the Image buffer.
+                            On return, points to the size, in bytes, of firmware
+                            image currently stored in the firmware device.
+
+  @retval EFI_SUCCESS            Image contains a copy of the firmware image
+                                 currently stored in the firmware device, and
+                                 ImageSize contains the size, in bytes, of the
+                                 firmware image currently stored in the
+                                 firmware device.
+  @retval EFI_BUFFER_TOO_SMALL   The buffer specified by ImageSize is too small
+                                 to hold the firmware image currently stored in
+                                 the firmware device. The buffer size required
+                                 is returned in ImageSize.
+  @retval EFI_INVALID_PARAMETER  The Image is NULL.
+  @retval EFI_INVALID_PARAMETER  The ImageSize is NULL.
+  @retval EFI_UNSUPPORTED        The operation is not supported.
+  @retval EFI_DEVICE_ERROR       An error occurred attempting to retrieve the
+                                 firmware image currently stored in the firmware
+                                 device.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetImage (
+  OUT    VOID   *Image,
+  IN OUT UINTN  *ImageSize
+  )
+{
+  //
+  // This seems useful only if FMP device is part of the running firmware.
+  //
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Checks if a new firmware image is valid for the firmware device.  This
+  function allows firmware update operation to validate the firmware image
+  before FmpDeviceSetImage() is called.
+
+  @param[in]  Image           Points to a new firmware image.
+  @param[in]  ImageSize       Size, in bytes, of a new firmware image.
+  @param[out] ImageUpdatable  Indicates if a new firmware image is valid for
+                              a firmware update to the firmware device.  The
+                              following values from the Firmware Management
+                              Protocol are supported:
+                                IMAGE_UPDATABLE_VALID
+                                IMAGE_UPDATABLE_INVALID
+                                IMAGE_UPDATABLE_INVALID_TYPE
+                                IMAGE_UPDATABLE_INVALID_OLD
+                                IMAGE_UPDATABLE_VALID_WITH_VENDOR_CODE
+
+  @retval EFI_SUCCESS            The image was successfully checked.  Additional
+                                 status information is returned in
+                                 ImageUpdatable.
+  @retval EFI_INVALID_PARAMETER  Image is NULL.
+  @retval EFI_INVALID_PARAMETER  ImageUpdatable is NULL.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceCheckImage (
+  IN  CONST VOID  *Image,
+  IN  UINTN       ImageSize,
+  OUT UINT32      *ImageUpdatable
+  )
+{
+  UINT32  LastAttemptStatus;
+
+  return FmpDeviceCheckImageWithStatus (Image, ImageSize, ImageUpdatable, &LastAttemptStatus);
+}
+
+/**
+  Checks if a new firmware image is valid for the firmware device.  This
+  function allows firmware update operation to validate the firmware image
+  before FmpDeviceSetImage() is called.
+
+  @param[in]  Image               Points to a new firmware image.
+  @param[in]  ImageSize           Size, in bytes, of a new firmware image.
+  @param[out] ImageUpdatable      Indicates if a new firmware image is valid for
+                                  a firmware update to the firmware device.  The
+                                  following values from the Firmware Management
+                                  Protocol are supported:
+                                    IMAGE_UPDATABLE_VALID
+                                    IMAGE_UPDATABLE_INVALID
+                                    IMAGE_UPDATABLE_INVALID_TYPE
+                                    IMAGE_UPDATABLE_INVALID_OLD
+                                    IMAGE_UPDATABLE_VALID_WITH_VENDOR_CODE
+  @param[out] LastAttemptStatus   A pointer to a UINT32 that holds the last attempt
+                                  status to report back to the ESRT table in case
+                                  of error.
+
+                                  The return status code must fall in the range of
+                                  LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MIN_ERROR_CODE_VALUE to
+                                  LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MAX_ERROR_CODE_VALUE.
+
+                                  If the value falls outside this range, it will be converted
+                                  to LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL.
+
+  @retval EFI_SUCCESS            The image was successfully checked.  Additional
+                                 status information is returned in
+                                 ImageUpdatable.
+  @retval EFI_INVALID_PARAMETER  Image is NULL.
+  @retval EFI_INVALID_PARAMETER  ImageUpdatable is NULL.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceCheckImageWithStatus (
+  IN  CONST VOID  *Image,
+  IN  UINTN       ImageSize,
+  OUT UINT32      *ImageUpdatable,
+  OUT UINT32      *LastAttemptStatus
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       FwSize;
+  UINTN       BlockSize;
+
+  if (Image == NULL || ImageUpdatable == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
+  *ImageUpdatable    = IMAGE_UPDATABLE_INVALID;
+
+  Status = FmpDeviceGetSize (&FwSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): FmpDeviceGetSize() failed with: %r\n",
+            __FUNCTION__, Status));
+    return Status;
+  }
+
+  if (ImageSize != FwSize) {
+    DEBUG ((DEBUG_ERROR, "%a(): image size (0x%x) doesn't match firmware size (0x%x)\n",
+           __FUNCTION__, ImageSize, FwSize));
+    return EFI_ABORTED;
+  }
+
+  Status = SmmStoreLibGetBlockSize (&BlockSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): SmmStoreLibGetBlockSize() failed with: %r\n",
+            __FUNCTION__, Status));
+    return Status;
+  }
+
+  if (FwSize % BlockSize != 0) {
+    DEBUG ((DEBUG_ERROR, "%a(): firmware size (0x%x) is not a multiple of block size (0x%x)\n",
+           __FUNCTION__, FwSize, BlockSize));
+    return EFI_ABORTED;
+  }
+
+  *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
+  *ImageUpdatable    = IMAGE_UPDATABLE_VALID;
+  return EFI_SUCCESS;
+}
+
+/**
+  Updates a firmware device with a new firmware image.  This function returns
+  EFI_UNSUPPORTED if the firmware image is not updatable.  If the firmware image
+  is updatable, the function should perform the following minimal validations
+  before proceeding to do the firmware image update.
+    - Validate that the image is a supported image for this firmware device.
+      Return EFI_ABORTED if the image is not supported.  Additional details
+      on why the image is not a supported image may be returned in AbortReason.
+    - Validate the data from VendorCode if is not NULL.  Firmware image
+      validation must be performed before VendorCode data validation.
+      VendorCode data is ignored or considered invalid if image validation
+      fails.  Return EFI_ABORTED if the VendorCode data is invalid.
+
+  VendorCode enables vendor to implement vendor-specific firmware image update
+  policy.  Null if the caller did not specify the policy or use the default
+  policy.  As an example, vendor can implement a policy to allow an option to
+  force a firmware image update when the abort reason is due to the new firmware
+  image version is older than the current firmware image version or bad image
+  checksum.  Sensitive operations such as those wiping the entire firmware image
+  and render the device to be non-functional should be encoded in the image
+  itself rather than passed with the VendorCode.  AbortReason enables vendor to
+  have the option to provide a more detailed description of the abort reason to
+  the caller.
+
+  @param[in]  Image             Points to the new firmware image.
+  @param[in]  ImageSize         Size, in bytes, of the new firmware image.
+  @param[in]  VendorCode        This enables vendor to implement vendor-specific
+                                firmware image update policy.  NULL indicates
+                                the caller did not specify the policy or use the
+                                default policy.
+  @param[in]  Progress          A function used to report the progress of
+                                updating the firmware device with the new
+                                firmware image.
+  @param[in]  CapsuleFwVersion  The version of the new firmware image from the
+                                update capsule that provided the new firmware
+                                image.
+  @param[out] AbortReason       A pointer to a pointer to a Null-terminated
+                                Unicode string providing more details on an
+                                aborted operation. The buffer is allocated by
+                                this function with
+                                EFI_BOOT_SERVICES.AllocatePool().  It is the
+                                caller's responsibility to free this buffer with
+                                EFI_BOOT_SERVICES.FreePool().
+
+  @retval EFI_SUCCESS            The firmware device was successfully updated
+                                 with the new firmware image.
+  @retval EFI_ABORTED            The operation is aborted.  Additional details
+                                 are provided in AbortReason.
+  @retval EFI_INVALID_PARAMETER  The Image was NULL.
+  @retval EFI_UNSUPPORTED        The operation is not supported.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSetImage (
+  IN  CONST VOID                                     *Image,
+  IN  UINTN                                          ImageSize,
+  IN  CONST VOID                                     *VendorCode        OPTIONAL,
+  IN  EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Progress           OPTIONAL,
+  IN  UINT32                                         CapsuleFwVersion,
+  OUT CHAR16                                         **AbortReason
+  )
+{
+  UINT32  LastAttemptStatus;
+
+  return FmpDeviceSetImageWithStatus (
+           Image,
+           ImageSize,
+           VendorCode,
+           Progress,
+           CapsuleFwVersion,
+           AbortReason,
+           &LastAttemptStatus
+           );
+}
+
+/**
+  Advances progress of the operation by a single step, converts the steps to
+  percents and invokes a callback if there is one.
+
+  @param[in]      Callback              External callback for progress reporting
+                                        or NULL if there is none.
+  @param[in]      TotalSteps            Total number of flashing steps.
+  @param[in, out] Step                  Current step number.
+  @param[in, out] ShouldReportProgress  A flag indicating whether progress needs
+                                        to be reported.
+**/
+STATIC
+VOID
+IncrementProgress (
+  IN      EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Callback OPTIONAL,
+  IN      UINTN                                          TotalSteps,
+  IN OUT  UINTN                                          *Step,
+  IN OUT  BOOLEAN                                        *ShouldReportProgress
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Progress;
+
+  if (!*ShouldReportProgress) {
+    return;
+  }
+
+  if (Callback == NULL) {
+    *ShouldReportProgress = FALSE;
+    return;
+  }
+
+  ++*Step;
+  Progress = (*Step * 100) / TotalSteps;
+
+  //
+  // Value of 0 means "progress reporting is not supported", so avoid using it.
+  //
+  if (Progress == 0) {
+    Progress = 1;
+  }
+
+  Status = Callback (Progress);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "%a(): progress callback failed with: %r\n",
+            __FUNCTION__, Status));
+    *ShouldReportProgress = FALSE;
+  }
+}
+
+/**
+  This code finds variable in storage blocks (Volatile or Non-Volatile).
+
+  @param[in]      VariableName               Name of Variable to be found.
+  @param[in]      VendorGuid                 Variable vendor GUID.
+  @param[out]     Attributes                 Attribute value of the variable found.
+  @param[in, out] DataSize                   Size of Data found. If size is less than the
+                                             data, this value contains the required size.
+  @param[out]     Data                       Data pointer.
+
+  @return EFI_INVALID_PARAMETER     Invalid parameter.
+  @return EFI_SUCCESS               Find the specified variable.
+  @return EFI_NOT_FOUND             Not found.
+  @return EFI_BUFFER_TO_SMALL       DataSize is too small for the result.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetVariableHook (
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data
+  )
+{
+  DEBUG ((DEBUG_INFO, "%a(): %g:%S\n",
+          __FUNCTION__, VendorGuid, VariableName));
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  This code Finds the Next available variable.
+
+  @param[in, out] VariableNameSize           Size of the variable name.
+  @param[in, out] VariableName               Pointer to variable name.
+  @param[in, out] VendorGuid                 Variable Vendor Guid.
+
+  @return EFI_INVALID_PARAMETER     Invalid parameter.
+  @return EFI_SUCCESS               Find the specified variable.
+  @return EFI_NOT_FOUND             Not found.
+  @return EFI_BUFFER_TO_SMALL       DataSize is too small for the result.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetNextVariableNameHook (
+  IN OUT  UINTN     *VariableNameSize,
+  IN OUT  CHAR16    *VariableName,
+  IN OUT  EFI_GUID  *VendorGuid
+  )
+{
+  DEBUG ((DEBUG_INFO, "%a(): %g:%S\n",
+          __FUNCTION__, VendorGuid, VariableName));
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  This code sets variable in storage blocks (Volatile or Non-Volatile).
+
+  @param[in] VariableName                     Name of Variable to be found.
+  @param[in] VendorGuid                       Variable vendor GUID.
+  @param[in] Attributes                       Attribute value of the variable found
+  @param[in] DataSize                         Size of Data found. If size is less than the
+                                              data, this value contains the required size.
+  @param[in] Data                             Data pointer.
+
+  @return EFI_INVALID_PARAMETER           Invalid parameter.
+  @return EFI_SUCCESS                     Set successfully.
+  @return EFI_OUT_OF_RESOURCES            Resource not enough to set variable.
+  @return EFI_NOT_FOUND                   Not found.
+  @return EFI_WRITE_PROTECTED             Variable is read-only.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+SetVariableHook (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid,
+  IN UINT32    Attributes,
+  IN UINTN     DataSize,
+  IN VOID      *Data
+  )
+{
+  DEBUG ((DEBUG_INFO, "%a(): %g:%S, 0x%x bytes, 0x%x\n",
+          __FUNCTION__, VendorGuid, VariableName, DataSize, Attributes));
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  This code returns information about the EFI variables.
+
+  @param[in]  Attributes                     Attributes bitmask to specify the type of variables
+                                             on which to return information.
+  @param[out] MaximumVariableStorageSize     Pointer to the maximum size of the storage space available
+                                             for the EFI variables associated with the attributes specified.
+  @param[out] RemainingVariableStorageSize   Pointer to the remaining size of the storage space available
+                                             for EFI variables associated with the attributes specified.
+  @param[out] MaximumVariableSize            Pointer to the maximum size of an individual EFI variables
+                                             associated with the attributes specified.
+
+  @return EFI_SUCCESS                   Query successfully.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+QueryVariableInfoHook (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
+  )
+{
+  DEBUG ((DEBUG_INFO, "%a(): 0x%x\n", __FUNCTION__, Attributes));
+  return EFI_NOT_AVAILABLE_YET;
+}
+
+/**
+  Updates a firmware device with a new firmware image.  This function returns
+  EFI_UNSUPPORTED if the firmware image is not updatable.  If the firmware image
+  is updatable, the function should perform the following minimal validations
+  before proceeding to do the firmware image update.
+    - Validate that the image is a supported image for this firmware device.
+      Return EFI_ABORTED if the image is not supported.  Additional details
+      on why the image is not a supported image may be returned in AbortReason.
+    - Validate the data from VendorCode if is not NULL.  Firmware image
+      validation must be performed before VendorCode data validation.
+      VendorCode data is ignored or considered invalid if image validation
+      fails.  Return EFI_ABORTED if the VendorCode data is invalid.
+
+  VendorCode enables vendor to implement vendor-specific firmware image update
+  policy.  Null if the caller did not specify the policy or use the default
+  policy.  As an example, vendor can implement a policy to allow an option to
+  force a firmware image update when the abort reason is due to the new firmware
+  image version is older than the current firmware image version or bad image
+  checksum.  Sensitive operations such as those wiping the entire firmware image
+  and render the device to be non-functional should be encoded in the image
+  itself rather than passed with the VendorCode.  AbortReason enables vendor to
+  have the option to provide a more detailed description of the abort reason to
+  the caller.
+
+  @param[in]  Image             Points to the new firmware image.
+  @param[in]  ImageSize         Size, in bytes, of the new firmware image.
+  @param[in]  VendorCode        This enables vendor to implement vendor-specific
+                                firmware image update policy.  NULL indicates
+                                the caller did not specify the policy or use the
+                                default policy.
+  @param[in]  Progress          A function used to report the progress of
+                                updating the firmware device with the new
+                                firmware image.
+  @param[in]  CapsuleFwVersion  The version of the new firmware image from the
+                                update capsule that provided the new firmware
+                                image.
+  @param[out] AbortReason       A pointer to a pointer to a Null-terminated
+                                Unicode string providing more details on an
+                                aborted operation. The buffer is allocated by
+                                this function with
+                                EFI_BOOT_SERVICES.AllocatePool().  It is the
+                                caller's responsibility to free this buffer with
+                                EFI_BOOT_SERVICES.FreePool().
+  @param[out] LastAttemptStatus A pointer to a UINT32 that holds the last attempt
+                                status to report back to the ESRT table in case
+                                of error. This value will only be checked when this
+                                function returns an error.
+
+                                The return status code must fall in the range of
+                                LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MIN_ERROR_CODE_VALUE to
+                                LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MAX_ERROR_CODE_VALUE.
+
+                                If the value falls outside this range, it will be converted
+                                to LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL.
+
+  @retval EFI_SUCCESS            The firmware device was successfully updated
+                                 with the new firmware image.
+  @retval EFI_ABORTED            The operation is aborted.  Additional details
+                                 are provided in AbortReason.
+  @retval EFI_INVALID_PARAMETER  The Image was NULL.
+  @retval EFI_UNSUPPORTED        The operation is not supported.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSetImageWithStatus (
+  IN  CONST VOID                                     *Image,
+  IN  UINTN                                          ImageSize,
+  IN  CONST VOID                                     *VendorCode        OPTIONAL,
+  IN  EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Progress           OPTIONAL,
+  IN  UINT32                                         CapsuleFwVersion,
+  OUT CHAR16                                         **AbortReason,
+  OUT UINT32                                         *LastAttemptStatus
+  )
+{
+  EFI_STATUS   Status;
+  UINTN        BlockSize;
+  UINTN        BlockCount;
+  UINTN        Block;
+  UINTN        NumBytes;
+  UINTN        TotalSteps;
+  UINTN        Step;
+  BOOLEAN      ShouldReportProgress;
+  VOID         *ReadBuffer;
+  CONST UINT8  *WriteNext;
+
+  *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
+
+  //
+  // FmpDeviceCheckImageWithStatus() has already validated the image, so not
+  // repeating the checks.  However, could move the checks here to be able to
+  // report abort reason which can't be done in FmpDeviceCheckImageWithStatus().
+  //
+
+  Status = SmmStoreLibGetBlockSize (&BlockSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): SmmStoreLibGetBlockSize() failed with: %r\n",
+            __FUNCTION__, Status));
+    return Status;
+  }
+
+  ReadBuffer = AllocatePool (BlockSize);
+  if (ReadBuffer == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to allocate read buffer\n", __FUNCTION__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BlockCount = ImageSize / BlockSize;
+  DEBUG ((DEBUG_INFO, "%a(): 0x%x blocks of 0x%x bytes\n",
+          __FUNCTION__, BlockCount, BlockSize));
+
+  ShouldReportProgress = TRUE;
+  TotalSteps = BlockCount * 2;  // Erase and write of each block.
+  Step = 0;
+  WriteNext = Image;
+
+  for (Block = 0; Block < BlockCount; Block++, WriteNext += BlockSize) {
+    //
+    // Save the flash and time by only writing a block if new contents differs
+    // from the old one.
+    //
+    // This is an optimization, so ignore read errors (if they are indicative of
+    // a serious problem, erasing or writing will fail as well).
+    //
+    NumBytes = BlockSize;
+    Status = SmmStoreLibReadAnyBlock (Block, 0, &NumBytes, ReadBuffer);
+    if (!EFI_ERROR (Status) && NumBytes == BlockSize) {
+      if (CompareMem (ReadBuffer, WriteNext, BlockSize) == 0) {
+        // Erase step.
+        IncrementProgress (Progress, TotalSteps, &Step, &ShouldReportProgress);
+        // Write step.
+        IncrementProgress (Progress, TotalSteps, &Step, &ShouldReportProgress);
+        continue;
+      }
+    }
+
+    Status = SmmStoreLibEraseAnyBlock (Block);
+    if (EFI_ERROR (Status))
+      goto IoError;
+
+    IncrementProgress (Progress, TotalSteps, &Step, &ShouldReportProgress);
+
+    NumBytes = BlockSize;
+    Status = SmmStoreLibWriteAnyBlock (Block, 0, &NumBytes, (VOID *) WriteNext);
+    if (EFI_ERROR (Status) || NumBytes != BlockSize)
+      goto IoError;
+
+    IncrementProgress (Progress, TotalSteps, &Step, &ShouldReportProgress);
+  }
+
+  FreePool (ReadBuffer);
+
+  *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
+
+  //
+  // After the firmware on system flash was successfully updated working with
+  // variable store on the flash isn't safe.  Switch to the use of stubs which
+  // do nothing.
+  //
+  // New firmware will not report result of flashing in any way unless some
+  // kind of communication mechanism is implemented for this purpose.
+  //
+  // If there was an error, it's unclear whether these stubs would be of any
+  // help, so they are employed only on successful flashing.
+  //
+
+  gRT->GetVariable         = GetVariableHook;
+  gRT->GetNextVariableName = GetNextVariableNameHook;
+  gRT->SetVariable         = SetVariableHook;
+  gRT->QueryVariableInfo   = QueryVariableInfoHook;
+
+  gRT->Hdr.CRC32 = 0;
+  gBS->CalculateCrc32 (
+         (UINT8 *) &gRT->Hdr,
+         gRT->Hdr.HeaderSize,
+         &gRT->Hdr.CRC32
+         );
+
+  return EFI_SUCCESS;
+
+IoError:
+  //
+  // Would be nice to warn the user about potential brick state or maybe attempt
+  // a recovery.  Doesn't seem that the calling code will do any of it.
+  //
+  FreePool (ReadBuffer);
+  DEBUG ((DEBUG_ERROR, "%a(): flashing has failed at block 0x%x/0x%x: %r\n",
+          __FUNCTION__, Block, BlockCount, EFI_DEVICE_ERROR));
+  return EFI_DEVICE_ERROR;
+}
+
+/**
+  Lock the firmware device that contains a firmware image.  Once a firmware
+  device is locked, any attempts to modify the firmware image contents in the
+  firmware device must fail.
+
+  @note It is recommended that all firmware devices support a lock method to
+        prevent modifications to a stored firmware image.
+
+  @note A firmware device lock mechanism is typically only cleared by a full
+        system reset (not just sleep state/low power mode).
+
+  @retval  EFI_SUCCESS      The firmware device was locked.
+  @retval  EFI_UNSUPPORTED  The firmware device does not support locking
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceLock (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Constructor that performs required initialization.
+
+  @param ImageHandle  The image handle of the process.
+  @param SystemTable  The EFI System Table pointer.
+
+  @retval EFI_SUCCESS  Initialization was successful.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSmmLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  SmmStoreLibInitialize ();
+  return EFI_SUCCESS;
+}

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -1,0 +1,45 @@
+## @file
+#  Provides firmware device specific services to support updates of a firmware
+#  image stored in a firmware device.
+#
+#  Copyright (c) 2016, Microsoft Corporation. All rights reserved.<BR>
+#  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION     = 0x00010005
+  BASE_NAME       = FmpDeviceSmmLib
+  MODULE_UNI_FILE = FmpDeviceSmmLib.uni
+  FILE_GUID       = 979CF0F8-7214-4D12-89CE-F32112ED71C6
+  MODULE_TYPE     = DXE_DRIVER
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = FmpDeviceLib|DXE_DRIVER UEFI_DRIVER
+  CONSTRUCTOR     = FmpDeviceSmmLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  FmpDeviceSmmLib.c
+
+[LibraryClasses]
+  BaseMemoryLib
+  BlParseLib
+  DebugLib
+  MemoryAllocationLib
+  PrintLib
+  SmmStoreLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.uni
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.uni
@@ -1,0 +1,13 @@
+// /** @file
+// Provides firmware device specific services to support updates of a firmware
+// image stored in a firmware device.
+//
+// Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT     #language en-US  "Provides firmware device specific services to support updates of a firmware image stored in a firmware device."
+
+#string STR_MODULE_DESCRIPTION  #language en-US  "Provides firmware device specific services to support updates of a firmware image stored in a firmware device."

--- a/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.c
+++ b/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.c
@@ -1,6 +1,7 @@
 /** @file  SmmStore.c
 
   Copyright (c) 2022, 9elements GmbH<BR>
+  Copyright (c) 2024, 3mdeb Sp. z o.o.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -139,6 +140,52 @@ SmmStoreLibGetMmioAddress (
 }
 
 /**
+  Read a flash block.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param[in] Lba      The starting logical block index to read from.
+  @param[in] Offset   Offset into the block at which to begin reading.
+  @param[in] NumBytes On input, indicates the requested read size. On
+                      output, indicates the actual number of bytes read
+  @param[in] Buffer   Pointer to the buffer to read into.
+  @param[in] ReadCmd  Read command to use.
+
+  @note Validation of mSmmStoreInfo and Lba must be done by the calling code.
+
+**/
+STATIC
+EFI_STATUS
+ReadBlock (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer,
+  IN        UINT8    ReadCmd
+  )
+{
+  EFI_STATUS  Status;
+
+  if (((*NumBytes + Offset) > mSmmStoreInfo->BlockSize) ||
+      ((*NumBytes + Offset) > mSmmStoreInfo->ComBufferSize))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  mArgComBuf->Read.BufSize   = *NumBytes;
+  mArgComBuf->Read.BufOffset = Offset;
+  mArgComBuf->Read.BlockId   = Lba;
+
+  Status = CallSmm (mSmmStoreInfo->ApmCmd, ReadCmd, mArgComBufPhys);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  CopyMem (Buffer, (VOID *)(UINTN)(mSmmStoreInfo->ComBuffer + Offset), *NumBytes);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Read from SmmStore
 
   @param[in] Lba      The starting logical block index to read from.
@@ -156,8 +203,6 @@ SmmStoreLibRead (
   IN        UINT8    *Buffer
   )
 {
-  EFI_STATUS  Status;
-
   if (mSmmStoreInfo == NULL) {
     return EFI_NO_MEDIA;
   }
@@ -166,24 +211,72 @@ SmmStoreLibRead (
     return EFI_INVALID_PARAMETER;
   }
 
+  return ReadBlock (Lba, Offset, NumBytes, Buffer, SMMSTORE_CMD_RAW_READ);
+}
+
+/**
+  Read from an arbitrary flash location.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param[in] Lba      The starting logical block index to read from.
+  @param[in] Offset   Offset into the block at which to begin reading.
+  @param[in] NumBytes On input, indicates the requested read size. On
+                      output, indicates the actual number of bytes read
+  @param[in] Buffer   Pointer to the buffer to read into.
+
+**/
+EFI_STATUS
+SmmStoreLibReadAnyBlock (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  return ReadBlock (Lba, Offset, NumBytes, Buffer, SMMSTORE_CMD_USE_FULL_FLASH | SMMSTORE_CMD_RAW_READ);
+}
+
+/**
+  Write a flash block.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param[in] Lba      The starting logical block index to write to.
+  @param[in] Offset   Offset into the block at which to begin writing.
+  @param[in] NumBytes On input, indicates the requested write size. On
+                      output, indicates the actual number of bytes written
+  @param[in] Buffer   Pointer to the data to write.
+  @param[in] WriteCmd Write command to use.
+
+  @note Validation of mSmmStoreInfo and Lba must be done by the calling code.
+
+**/
+STATIC
+EFI_STATUS
+WriteBlock (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer,
+  IN        UINT8    WriteCmd
+  )
+{
   if (((*NumBytes + Offset) > mSmmStoreInfo->BlockSize) ||
       ((*NumBytes + Offset) > mSmmStoreInfo->ComBufferSize))
   {
     return EFI_INVALID_PARAMETER;
   }
 
-  mArgComBuf->Read.BufSize   = *NumBytes;
-  mArgComBuf->Read.BufOffset = Offset;
-  mArgComBuf->Read.BlockId   = Lba;
+  mArgComBuf->Write.BufSize   = *NumBytes;
+  mArgComBuf->Write.BufOffset = Offset;
+  mArgComBuf->Write.BlockId   = Lba;
 
-  Status = CallSmm (mSmmStoreInfo->ApmCmd, SMMSTORE_CMD_RAW_READ, mArgComBufPhys);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+  CopyMem ((VOID *)(UINTN)(mSmmStoreInfo->ComBuffer + Offset), Buffer, *NumBytes);
 
-  CopyMem (Buffer, (VOID *)(UINTN)(mSmmStoreInfo->ComBuffer + Offset), *NumBytes);
-
-  return EFI_SUCCESS;
+  return CallSmm (mSmmStoreInfo->ApmCmd, WriteCmd, mArgComBufPhys);
 }
 
 /**
@@ -212,19 +305,33 @@ SmmStoreLibWrite (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (((*NumBytes + Offset) > mSmmStoreInfo->BlockSize) ||
-      ((*NumBytes + Offset) > mSmmStoreInfo->ComBufferSize))
-  {
-    return EFI_INVALID_PARAMETER;
+  return WriteBlock (Lba, Offset, NumBytes, Buffer, SMMSTORE_CMD_RAW_WRITE);
+}
+
+/**
+  Write to an arbitrary flash location.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param[in] Lba      The starting logical block index to write to.
+  @param[in] Offset   Offset into the block at which to begin writing.
+  @param[in] NumBytes On input, indicates the requested write size. On
+                      output, indicates the actual number of bytes written
+  @param[in] Buffer   Pointer to the data to write.
+
+**/
+EFI_STATUS
+SmmStoreLibWriteAnyBlock (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
   }
 
-  mArgComBuf->Write.BufSize   = *NumBytes;
-  mArgComBuf->Write.BufOffset = Offset;
-  mArgComBuf->Write.BlockId   = Lba;
-
-  CopyMem ((VOID *)(UINTN)(mSmmStoreInfo->ComBuffer + Offset), Buffer, *NumBytes);
-
-  return CallSmm (mSmmStoreInfo->ApmCmd, SMMSTORE_CMD_RAW_WRITE, mArgComBufPhys);
+  return WriteBlock (Lba, Offset, NumBytes, Buffer, SMMSTORE_CMD_USE_FULL_FLASH | SMMSTORE_CMD_RAW_WRITE);
 }
 
 /**
@@ -249,6 +356,29 @@ SmmStoreLibEraseBlock (
   mArgComBuf->Clear.BlockId = Lba;
 
   return CallSmm (mSmmStoreInfo->ApmCmd, SMMSTORE_CMD_RAW_CLEAR, mArgComBufPhys);
+}
+
+/**
+  Erase an arbitrary block of the flash.  The whole flash is represented as a
+  sequence of blocks.
+
+  @param Lba    The logical block index to erase.
+
+**/
+EFI_STATUS
+SmmStoreLibEraseAnyBlock (
+  IN   EFI_LBA  Lba
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  mArgComBuf->Clear.BlockId = Lba;
+
+  return CallSmm (mSmmStoreInfo->ApmCmd,
+                  SMMSTORE_CMD_USE_FULL_FLASH | SMMSTORE_CMD_RAW_CLEAR,
+                  mArgComBufPhys);
 }
 
 /**

--- a/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.h
+++ b/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.h
@@ -1,6 +1,7 @@
 /** @file  SmmStore.h
 
   Copyright (c) 2022, 9elements GmbH<BR>
+  Copyright (c) 2024, 3mdeb Sp. z o.o.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -18,6 +19,9 @@
 #define SMMSTORE_CMD_RAW_READ   5
 #define SMMSTORE_CMD_RAW_WRITE  6
 #define SMMSTORE_CMD_RAW_CLEAR  7
+
+/* Used by capsule updates as a standalone command or modifier to v2 commands */
+#define SMMSTORE_CMD_USE_FULL_FLASH  0x80
 
 /*
  * This allows the payload to store raw data in the flash regions.

--- a/DasharoPayloadPkg/Library/SmmStoreLib/SmmStoreLib.inf
+++ b/DasharoPayloadPkg/Library/SmmStoreLib/SmmStoreLib.inf
@@ -29,7 +29,6 @@
   HobLib
   MemoryAllocationLib
   UefiBootServicesTableLib
-  UefiRuntimeLib
 
 [Guids]
   gEfiSmmStoreInfoHobGuid           ## CONSUMES

--- a/DasharoPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntime.c
+++ b/DasharoPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntime.c
@@ -137,6 +137,8 @@ SmmStoreVirtualNotifyEvent (
   IN VOID       *Context
   )
 {
+  SmmStoreLibVirtualAddressChange (EfiConvertPointer);
+
   // Convert Fvb
   EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.EraseBlocks);
   EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.GetAttributes);

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleReset.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleReset.c
@@ -24,5 +24,9 @@ IsPersistAcrossResetCapsuleSupported (
   VOID
   )
 {
+  if (!DasharoCapsulesCanPersistAcrossReset()) {
+    return FALSE;
+  }
+
   return FeaturePcdGet (PcdSupportUpdateCapsuleReset);
 }

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
@@ -51,6 +51,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  DasharoModulePkg/DasharoModulePkg.dec
 
 [LibraryClasses]
   UefiBootServicesTableLib
@@ -64,6 +65,7 @@
   PrintLib
   BaseMemoryLib
   CacheMaintenanceLib
+  DasharoVariablesLib
 
 [LibraryClasses.X64]
   UefiLib

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
@@ -183,6 +183,16 @@ UpdateCapsule (
     return EFI_UNSUPPORTED;
   }
 
+  if (InitiateReset) {
+    //
+    // Request going into update mode after reboot to have full access to flash.
+    //
+    Status = DasharoEnableFUM ();
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
   CapsuleCacheWriteBack (ScatterGatherList);
 
   //

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.h
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.h
@@ -30,6 +30,7 @@
 #include <Library/BaseLib.h>
 #include <Library/PrintLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DasharoVariablesLib.h>
 
 /**
   Create the variable to save the base address of page table and stack


### PR DESCRIPTION
Due to https://github.com/Dasharo/dasharo-issues/issues/800#issuecomment-2247928107, update capsules aren't accepted unless ME is HAP-disabled.  This has a side effect of preventing update in Q35.  Don't yet know how to test for QEMU or otherwise circumvent the check for Q35, but that's a minor thing.

***

- FUM is enabled before rebooting to handle a persistent capsule
- SmmStoreLib can now be used in `DXE` modules, not just in `DXE_RUNTIME`, and is used by FmpDxe which gets embedded into a capsule, the embedding is done by adding a section like this to JSON file passed to `GenerateCapsule`:
```json
    "EmbeddedDrivers": [
        {
            "Driver": "../Build/DasharoPayloadPkgX64/RELEASE_COREBOOT/X64/FmpDxe.efi"
        }
    ],
```