### PR TITLE
DasharoPayloadPkg/PlatformBootManagerLib: Add missing BlParseLib in the INF file

### DIFF
--- a/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -54,6 +54,7 @@
   Tcg2PhysicalPresenceLib
   CustomizedDisplayLib
   LaptopBatteryLib
+  BlParseLib
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid


### PR DESCRIPTION
Fix build complaining on missing ParseVBootWorkbuf.