### PR TITLE
adds -Wformat to build flags

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -141,7 +141,7 @@
   DEFINE NETWORK_IPXE                   = FALSE
 
 [BuildOptions]
-  *_*_*_CC_FLAGS                 = -D DISABLE_NEW_DEPRECATED_INTERFACES -Wno-stringop-overflow
+  *_*_*_CC_FLAGS                 = -D DISABLE_NEW_DEPRECATED_INTERFACES -Wno-stringop-overflow -Wformat
 !if ($(USE_CBMEM_FOR_CONSOLE) == FALSE)
   GCC:RELEASE_*_*_CC_FLAGS       = -DMDEPKG_NDEBUG
   INTEL:RELEASE_*_*_CC_FLAGS     = /D MDEPKG_NDEBUG


### PR DESCRIPTION
there seems to be a compilation issue:
> cc1: error: '-Wformat-security' ignored without '-Wformat'

  
  my build command looks as follows:
  ```bash 
build -a IA32 -a X64 -b RELEASE -p UefiPayloadPkg/UefiPayloadPkg.dsc -t GCC5 -n 0 \
-D BOOTLOADER=COREBOOT -D ABOVE_4G_MEMORY=FALSE -D BOOTSPLASH_IMAGE=TRUE --pcd gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency=38400000 \
-D SERIAL_TERMINAL=TRUE -D FOLLOW_BGRT_SPEC=TRUE --pcd gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress=0xc0000000 \
--pcd gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseSize=0x10000000 -D PRIORITIZE_INTERNAL=TRUE -D PS2_KEYBOARD_ENABLE=TRUE \
-D PLATFORM_BOOT_TIMEOUT=3 -D SIO_BUS_ENABLE=TRUE -D USE_CBMEM_FOR_CONSOLE=TRUE -D SD_MMC_TIMEOUT=10000 -D NETWORK_IPXE=TRUE \
--pcd gUefiPayloadPkgTokenSpaceGuid.PcdiPXEOptionName=L"iPXE Network Boot" -D SECURE_BOOT_ENABLE=TRUE -D SECURE_BOOT_DEFAULT_ENABLE=FALSE \
-D SATA_PASSWORD_ENABLE=TRUE -D OPAL_PASSWORD_ENABLE=TRUE -D SETUP_PASSWORD_ENABLE=TRUE -D TPM_ENABLE=TRUE -D IOMMU_ENABLE=TRUE \
-D DASHARO_SYSTEM_FEATURES_ENABLE=TRUE --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowSecurityMenu=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIntelMeMenu=TRUE --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowNetworkMenu=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowUsbMenu=TRUE --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowChipsetMenu=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultPowerFailureState=0 --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPowerMenu=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowSleepType=FALSE --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPciMenu=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowMemoryMenu=TRUE --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault=600 --pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdPciMenuShowResizeableBars=TRUE \
--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdCreatePreInstalledBootOptions=TRUE -D PERFORMANCE_MEASUREMENT_ENABLE=TRUE \
--pcd gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeDefaultState=0 -D RAM_DISK_ENABLE=TRUE -D BOOT_MENU_KEY=0x0015 \
-D SETUP_MENU_KEY=0x0008 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow=0 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn=0 \
--pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupConOutRow=0 --pcd gEfiMdeModulePkgTokenSpaceGuid.PcdSetupConOutColumn=0 \
-y ~/workspace/coreboot-dasharo/payloads/external/edk2/workspace/Build/UefiPayloadPkgX64/UEFIPAYLOAD.txt;
```

and im building with a nix flake:
```
{
  description = "coreboot-edk2";

  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/23.11";
  };

  outputs = { self, nixpkgs }:
    let
      pkgs = nixpkgs.legacyPackages.x86_64-linux.pkgs;
    in {
      devShells.x86_64-linux.default = pkgs.mkShell {
        name = "foo";
        packages = with pkgs; [
          autogen
          bash
          bison
          coreboot-toolchain.i386
          coreboot-toolchain.x64
          coreutils-full
          git
          gnumake
          libuuid libuuid.dev
          libxcrypt
          m4
          mpfr mpfr.dev
          nasm
          ncurses5 ncurses5.dev
          openssl openssl.dev
          perl
          pkg-config
          python38
          xz xz.dev
          zlib zlib.dev
        ];
        buildInputs = with pkgs; [
          libuuid.lib
          libxcrypt
          mpfr.dev
          ncurses5.dev
          openssl.dev
          xz.dev
          zlib.dev
        ];
        shellHook = ''
          export CPUS=$(nproc);
          export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-vla-parameter -Wno-stringop-overflow -Wno-use-after-free -Wno-dangling-pointer"
#         export TMPDIR="/tmp";
          echo "cp configs/config.msi_ms7d25_ddr5 .config;";
          echo "make olddefconfig && make -j\$(nproc);"
        '';
      };
    };
}
```