### PR TITLE
UefiPayloadPkg/UefiPayloadPkg.dsc: Disable 1G pages

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -438,7 +438,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize|0x8000
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize|0x10000
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
-  gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|TRUE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
   gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|8000
   # 4K displays may need bigger buffers for the option strings in forms


### PR DESCRIPTION
ESXi bootloader does not seem to cope well with 1G pages and page tables. On VP6670 it caused a #PF on frambuffer access. However, the issue was not reproduced on MSI MS-7D25 DDR4 nor QEMU. The ESXi bootloader allocates memory for a copy of page tables. On the first run of the page tabel parser it returns how many tables it has to determine how many 4K chunks to allocate for the copy. Then it goes through all of the page tables again and copies those it consideres valid (PA == VA, present bit set). However, the parser incorrectly calculates the numebr of page tables and the buffer for page table copy is underallocated. As a result the pages tables containing the framebuffer (and all subsequent page tables) were not copied by the bootloader, causing a #PF when the bootloader switched to the page table copy it just made. Apparently it does a slightly better job with 2M pages, so disable 1G pages as a workaround to get ESXI booting.