### PR TITLE
Allow enabling PCR banks according to configuration

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
+++ b/SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.c
@@ -307,7 +307,7 @@ SyncPcrAllocationsAndPcrMask (
   {
     DEBUG ((DEBUG_INFO, "TpmActivePcrBanks & Tpm2PcrMask = 0x%08x\n", (TpmActivePcrBanks & Tpm2PcrMask)));
     DEBUG ((DEBUG_INFO, "TpmActivePcrBanks & BiosHashAlgorithmBitmap = 0x%08x\n", (TpmActivePcrBanks & BiosHashAlgorithmBitmap)));
-    NewTpmActivePcrBanks  = TpmActivePcrBanks;
+    NewTpmActivePcrBanks  = TpmHashAlgorithmBitmap;
     NewTpmActivePcrBanks &= Tpm2PcrMask;
     NewTpmActivePcrBanks &= BiosHashAlgorithmBitmap;
     DEBUG ((DEBUG_INFO, "NewTpmActivePcrBanks 0x%08x\n", NewTpmActivePcrBanks));


### PR DESCRIPTION
Prior to this change the code could only disable banks unsupported by the BIOS and not enable those which are supported.  This resulted in not touching TPM configuration if an unsupported bank was already selected instead of automatically switching on supported banks.

Unsupported hashes also get hidden from UI.

See https://github.com/Dasharo/dasharo-issues/issues/982 for context.

coreboot PR: https://github.com/Dasharo/coreboot/pull/546