### PR TITLE
Fix MbedTLS allocations at runtime

### DIFF
--- a/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c
@@ -135,7 +135,8 @@ gmtime (
   const time_t  *timer
   )
 {
-  struct tm  *GmTime;
+  STATIC struct tm  GmTime;
+
   UINT64     DayNo;
   UINT64     DayRemainder;
   time_t     Year;
@@ -148,23 +149,18 @@ gmtime (
     return NULL;
   }
 
-  GmTime = malloc (sizeof (struct tm));
-  if (GmTime == NULL) {
-    return NULL;
-  }
-
-  ZeroMem ((VOID *)GmTime, (UINTN)sizeof (struct tm));
+  ZeroMem ((VOID *)&GmTime, (UINTN)sizeof (GmTime));
 
   DayNo        = (UINT64)DivS64x64Remainder (*timer, SECSPERDAY, &Remainder);
   DayRemainder = (UINT64)Remainder;
 
   DivS64x64Remainder (DayRemainder, SECSPERMIN, &Remainder);
-  GmTime->tm_sec = (int)Remainder;
+  GmTime.tm_sec = (int)Remainder;
   DivS64x64Remainder (DayRemainder, SECSPERHOUR, &Remainder);
-  GmTime->tm_min  = (int)DivS64x64Remainder (Remainder, SECSPERMIN, NULL);
-  GmTime->tm_hour = (int)DivS64x64Remainder (DayRemainder, SECSPERHOUR, NULL);
+  GmTime.tm_min  = (int)DivS64x64Remainder (Remainder, SECSPERMIN, NULL);
+  GmTime.tm_hour = (int)DivS64x64Remainder (DayRemainder, SECSPERHOUR, NULL);
   DivS64x64Remainder ((DayNo + 4), 7, &Remainder);
-  GmTime->tm_wday = (int)Remainder;
+  GmTime.tm_wday = (int)Remainder;
 
   for (Year = 1970, YearNo = 0; DayNo > 0; Year++) {
     TotalDays = (UINT32)(IsLeap (Year) ? 366 : 365);
@@ -176,8 +172,8 @@ gmtime (
     }
   }
 
-  GmTime->tm_year = (int)(YearNo + (1970 - 1900));
-  GmTime->tm_yday = (int)DayNo;
+  GmTime.tm_year = (int)(YearNo + (1970 - 1900));
+  GmTime.tm_yday = (int)DayNo;
 
   for (MonthNo = 12; MonthNo > 1; MonthNo--) {
     if (DayNo >= CumulativeDays[IsLeap (Year)][MonthNo]) {
@@ -186,12 +182,12 @@ gmtime (
     }
   }
 
-  GmTime->tm_mon  = (int)MonthNo - 1;
-  GmTime->tm_mday = (int)DayNo + 1;
+  GmTime.tm_mon  = (int)MonthNo - 1;
+  GmTime.tm_mday = (int)DayNo + 1;
 
-  GmTime->tm_isdst  = 0;
-  GmTime->tm_gmtoff = 0;
-  GmTime->tm_zone   = NULL;
+  GmTime.tm_isdst  = 0;
+  GmTime.tm_gmtoff = 0;
+  GmTime.tm_zone   = NULL;
 
-  return GmTime;
+  return &GmTime;
 }

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Hmac/CryptHmac.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Hmac/CryptHmac.c
@@ -24,10 +24,13 @@ HmacMdNew (
 {
   VOID  *HmacMdCtx;
 
-  HmacMdCtx = AllocateZeroPool (sizeof (mbedtls_md_context_t));
+  HmacMdCtx = calloc (sizeof (mbedtls_md_context_t), 1);
   if (HmacMdCtx == NULL) {
     return NULL;
   }
+
+  // XXX: No mbedtls_md_init()?  mbedtls_md_free() shouldn't be called in this
+  //      case.  `HmacMdFree (HmacMdNew ())` can cause problems.
 
   return HmacMdCtx;
 }
@@ -44,9 +47,7 @@ HmacMdFree (
   )
 {
   mbedtls_md_free (HmacMdCtx);
-  if (HmacMdCtx != NULL) {
-    FreePool (HmacMdCtx);
-  }
+  free (HmacMdCtx);
 }
 
 /**

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pem/CryptPem.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pem/CryptPem.c
@@ -52,7 +52,7 @@ RsaGetPrivateKeyFromPem (
 
   NewPemData = NULL;
   if (PemData[PemSize - 1] != 0) {
-    NewPemData = AllocateZeroPool (PemSize + 1);
+    NewPemData = calloc (PemSize + 1, 1);
     if (NewPemData == NULL) {
       return FALSE;
     }
@@ -73,10 +73,8 @@ RsaGetPrivateKeyFromPem (
 
   Ret = mbedtls_pk_parse_key (&Pk, PemData, PemSize, (CONST UINT8 *)Password, PasswordLen, NULL, NULL);
 
-  if (NewPemData != NULL) {
-    FreePool (NewPemData);
-    NewPemData = NULL;
-  }
+  free (NewPemData);
+  NewPemData = NULL;
 
   if (Ret != 0) {
     mbedtls_pk_free (&Pk);

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaBasic.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptRsaBasic.c
@@ -33,7 +33,7 @@ RsaNew (
 {
   VOID  *RsaContext;
 
-  RsaContext = AllocateZeroPool (sizeof (mbedtls_rsa_context));
+  RsaContext = calloc (sizeof (mbedtls_rsa_context), 1);
   if (RsaContext == NULL) {
     return RsaContext;
   }
@@ -59,9 +59,7 @@ RsaFree (
   )
 {
   mbedtls_rsa_free (RsaContext);
-  if (RsaContext != NULL) {
-    FreePool (RsaContext);
-  }
+  free (RsaContext);
 }
 
 /**

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/Pk/CryptX509.c
@@ -82,7 +82,7 @@ X509ConstructCertificate (
     return FALSE;
   }
 
-  MbedTlsCert = AllocateZeroPool (sizeof (mbedtls_x509_crt));
+  MbedTlsCert = calloc (sizeof (mbedtls_x509_crt), 1);
   if (MbedTlsCert == NULL) {
     return FALSE;
   }
@@ -95,7 +95,7 @@ X509ConstructCertificate (
     return TRUE;
   } else {
     mbedtls_x509_crt_free (MbedTlsCert);
-    FreePool (MbedTlsCert);
+    free (MbedTlsCert);
     return FALSE;
   }
 }
@@ -139,7 +139,7 @@ X509ConstructCertificateStackV (
   Ret = 0;
   Crt = NULL;
   if (*X509Stack == NULL) {
-    Crt = AllocateZeroPool (sizeof (mbedtls_x509_crt));
+    Crt = calloc (sizeof (mbedtls_x509_crt), 1);
     if (Crt == NULL) {
       return FALSE;
     }
@@ -174,7 +174,7 @@ X509ConstructCertificateStackV (
   } else {
     if (Crt != NULL) {
       mbedtls_x509_crt_free (Crt);
-      FreePool (Crt);
+      free (Crt);
       *X509Stack = NULL;
     }
 
@@ -230,7 +230,7 @@ X509Free (
 {
   if (X509Cert != NULL) {
     mbedtls_x509_crt_free (X509Cert);
-    FreePool (X509Cert);
+    free (X509Cert);
   }
 }
 

--- a/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/TimerWrapper.c
+++ b/CryptoPkg/Library/BaseCryptLibMbedTls/SysCall/TimerWrapper.c
@@ -113,7 +113,8 @@ gmtime (
   const time_t  *timer
   )
 {
-  struct tm  *GmTime;
+  STATIC struct tm  GmTime;
+
   UINT16     DayNo;
   UINT16     DayRemainder;
   time_t     Year;
@@ -125,20 +126,15 @@ gmtime (
     return NULL;
   }
 
-  GmTime = AllocateZeroPool (sizeof (struct tm));
-  if (GmTime == NULL) {
-    return NULL;
-  }
-
-  ZeroMem ((VOID *)GmTime, (UINTN)sizeof (struct tm));
+  ZeroMem ((VOID *)&GmTime, (UINTN)sizeof (GmTime));
 
   DayNo        = (UINT16)(*timer / SECSPERDAY);
   DayRemainder = (UINT16)(*timer % SECSPERDAY);
 
-  GmTime->tm_sec  = (int)(DayRemainder % SECSPERMIN);
-  GmTime->tm_min  = (int)((DayRemainder % SECSPERHOUR) / SECSPERMIN);
-  GmTime->tm_hour = (int)(DayRemainder / SECSPERHOUR);
-  GmTime->tm_wday = (int)((DayNo + 4) % 7);
+  GmTime.tm_sec  = (int)(DayRemainder % SECSPERMIN);
+  GmTime.tm_min  = (int)((DayRemainder % SECSPERHOUR) / SECSPERMIN);
+  GmTime.tm_hour = (int)(DayRemainder / SECSPERHOUR);
+  GmTime.tm_wday = (int)((DayNo + 4) % 7);
 
   for (Year = 1970, YearNo = 0; DayNo > 0; Year++) {
     TotalDays = (UINT16)(IsLeap (Year) ? 366 : 365);
@@ -150,8 +146,8 @@ gmtime (
     }
   }
 
-  GmTime->tm_year = (int)(YearNo + (1970 - 1900));
-  GmTime->tm_yday = (int)DayNo;
+  GmTime.tm_year = (int)(YearNo + (1970 - 1900));
+  GmTime.tm_yday = (int)DayNo;
 
   for (MonthNo = 12; MonthNo > 1; MonthNo--) {
     if (DayNo >= CumulativeDays[IsLeap (Year)][MonthNo]) {
@@ -160,14 +156,14 @@ gmtime (
     }
   }
 
-  GmTime->tm_mon  = (int)MonthNo - 1;
-  GmTime->tm_mday = (int)DayNo + 1;
+  GmTime.tm_mon  = (int)MonthNo - 1;
+  GmTime.tm_mday = (int)DayNo + 1;
 
-  GmTime->tm_isdst  = 0;
-  GmTime->tm_gmtoff = 0;
-  GmTime->tm_zone   = NULL;
+  GmTime.tm_isdst  = 0;
+  GmTime.tm_gmtoff = 0;
+  GmTime.tm_zone   = NULL;
 
-  return GmTime;
+  return &GmTime;
 }
 
 /**_time64 function. **/


### PR DESCRIPTION
As was recently reported on Matrix for CachyOS on Nova Custom V56 and in https://github.com/Dasharo/dasharo-issues/issues/1001 for FreeBSD on Protectli V1410, EFI runtime can crash when dealing with SecureBoot EFI variables as in https://github.com/Dasharo/edk2/pull/129#issuecomment-2150198582.

I originally fixed it only in a single file which showed up in https://github.com/Dasharo/edk2/pull/129#issuecomment-2153493525 and somehow concluded that it should be enough which wasn't true.  This attempt should be more successful, making it a PR so that more people can take a look and/or test.

The issue can be reproduced in QEMU and probably anywhere else.  I installed Debian, reset SecureBoot keys, downloaded https://github.com/Foxboron/sbctl/releases/tag/0.15.4 binary and tried following https://wiki.cachyos.org/configuration/secure_boot_setup/#setting-up-sbctl.  `sbctl enroll-keys -m` failed the same way it was described on Matrix.  The build from this branch succeeded.

Read commit messages for more details.

P.S. Maybe this should also be sent upstream, which lacks these and some other fixes made previously.