### PR TITLE
OvmfPkg: DxeTcg2PhysicalPresenceLib: fix changing of PCR banks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         fi
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ovmf-artifacts  # Name for the artifact
         path: |

--- a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
+++ b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
@@ -32,6 +32,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/CacheMaintenanceLib.h>
 
 #include <Library/Tcg2PhysicalPresenceLib.h>
 
@@ -902,6 +903,7 @@ Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (
 
   mPpi->Request = OperationRequest;
   mPpi->RequestParameter = RequestParameter;
+  WriteBackDataCache();
 
   return TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS;
 }

--- a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
+++ b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
@@ -733,6 +733,8 @@ Tcg2ExecutePendingTpmRequest (
     mPpi->LastRequest = mPpi->Request;
     mPpi->Request = TCG2_PHYSICAL_PRESENCE_NO_ACTION;
     mPpi->RequestParameter = 0;
+
+    WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
     return;
   }
 
@@ -763,6 +765,7 @@ Tcg2ExecutePendingTpmRequest (
   mPpi->RequestParameter = 0;
 
   if (mPpi->Response == TCG_PP_OPERATION_RESPONSE_USER_ABORT) {
+    WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
     return;
   }
 
@@ -791,6 +794,7 @@ Tcg2ExecutePendingTpmRequest (
   }
 
   Print (L"Rebooting system to make TPM2 settings in effect\n");
+  WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
   gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
   ASSERT (FALSE);
 }
@@ -903,7 +907,7 @@ Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (
 
   mPpi->Request = OperationRequest;
   mPpi->RequestParameter = RequestParameter;
-  WriteBackDataCache();
+  WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
 
   return TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS;
 }

--- a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
+++ b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
@@ -62,6 +62,7 @@
   UefiLib
   UefiRuntimeServicesTableLib
   Tcg2PhysicalPresencePlatformLib
+  CacheMaintenanceLib
 
 [Protocols]
   gEfiTcg2ProtocolGuid                 ## SOMETIMES_CONSUMES


### PR DESCRIPTION
Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction writes to TPM2 physical presence PPI provided by coreboot (a memory region preserved across reboots). CPU caches must be explicitly flushed prior to platform reboot or request written to PPI will be lost.