### PR TITLE
Preserve user data during firmware updates

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -294,6 +294,7 @@
   BlParseLib|DasharoPayloadPkg/Library/SblParseLib/SblParseLib.inf
 !endif
   FmapLib|DasharoPayloadPkg/Library/FmapLib/FmapLib.inf
+  CbfsLib|DasharoPayloadPkg/Library/CbfsLib/CbfsLib.inf
 
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -293,6 +293,7 @@
 !else
   BlParseLib|DasharoPayloadPkg/Library/SblParseLib/SblParseLib.inf
 !endif
+  FmapLib|DasharoPayloadPkg/Library/FmapLib/FmapLib.inf
 
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -295,6 +295,7 @@
 !endif
   FmapLib|DasharoPayloadPkg/Library/FmapLib/FmapLib.inf
   CbfsLib|DasharoPayloadPkg/Library/CbfsLib/CbfsLib.inf
+  EfiVarsLib|DasharoPayloadPkg/Library/EfiVarsLib/EfiVarsLib.inf
 
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf

--- a/DasharoPayloadPkg/Include/Library/CbfsLib.h
+++ b/DasharoPayloadPkg/Include/Library/CbfsLib.h
@@ -1,0 +1,6 @@
+#ifndef __CBFS_LIB__
+#define __CBFS_LIB__
+
+#include <Library/CbfsLib/cbfs_image.h>
+
+#endif

--- a/DasharoPayloadPkg/Include/Library/EfiVarsLib.h
+++ b/DasharoPayloadPkg/Include/Library/EfiVarsLib.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent */
+
+#ifndef __EFI_VARS_LIB__
+#define __EFI_VARS_LIB__
+
+#include <Uefi/UefiBaseType.h>
+#include <Uefi/UefiMultiPhase.h>
+#include <Pi/PiFirmwareVolume.h>
+#include <Guid/VariableFormat.h>
+
+typedef struct {
+  UINT8  *Start;
+  UINTN  Length;
+} MemRange;
+
+typedef struct EfiVar {
+  UINT32         Attrs;
+  EFI_GUID       Guid;
+  CHAR16         *Name;
+  UINTN          NameSize; // in bytes
+  UINT8          *Data;
+  UINTN          DataSize; // in bytes
+  struct EfiVar  *Next;
+} EfiVar;
+
+typedef struct {
+  MemRange  Fv;
+  MemRange  Store;
+  EfiVar    *Vars;
+} EfiVars;
+
+BOOLEAN
+EFIAPI
+EfiVarsInit (
+  IN OUT MemRange  Fv,
+  OUT    EfiVars   *Storage
+  );
+
+BOOLEAN
+EFIAPI
+EfiVarsWrite (
+  IN EfiVars  *Storage
+  );
+
+EfiVar *
+EFIAPI
+EfiVarsCreateVar (
+  IN EfiVars  *Storage
+  );
+
+VOID
+EFIAPI
+EfiVarsFree (
+  IN EfiVars  *Storage
+  );
+
+#endif

--- a/DasharoPayloadPkg/Include/Library/FmapLib.h
+++ b/DasharoPayloadPkg/Include/Library/FmapLib.h
@@ -1,0 +1,88 @@
+/** @file
+  coreboot flash map data parsing library.
+
+Copyright (c) 2024, coreboot project<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/* SPDX-License-Identifier: BSD-3-Clause or GPL-2.0-only */
+
+#ifndef FLASHMAP_LIB_FMAP_H__
+#define FLASHMAP_LIB_FMAP_H__
+
+#define FMAP_SIGNATURE    "__FMAP__"
+#define FMAP_VER_MAJOR    1          /* this header's FMAP minor version */
+#define FMAP_VER_MINOR    1          /* this header's FMAP minor version */
+#define FMAP_STRLEN      32          /* maximum length for strings (including *
+                                      * null-terminator) */
+
+/* Mapping of volatile and static regions in firmware binary */
+typedef struct {
+  UINT32 offset;            /* offset relative to base */
+  UINT32 size;              /* size in bytes */
+  UINT8  name[FMAP_STRLEN]; /* descriptive name */
+  UINT16 flags;             /* flags for this area */
+} __attribute__((packed)) FmapArea;
+
+typedef struct {
+  UINT8  signature[8];      /* "__FMAP__" (0x5F5F464D41505F5F) */
+  UINT8  ver_major;         /* major version */
+  UINT8  ver_minor;         /* minor version */
+  UINT64 base;              /* address of the firmware binary */
+  UINT32 size;              /* size of firmware binary in bytes */
+  UINT8  name[FMAP_STRLEN]; /* name of this firmware binary */
+  UINT16 nareas;            /* number of areas described by fmap_areas[] below */
+  FmapArea areas[];
+} __attribute__((packed)) Fmap;
+
+/*
+ * FmapFind - find FMAP signature in a binary Image
+ *
+ * @Image:  binary Image
+ * @Len:  length of binary Image
+ *
+ * This function does no error checking. The caller is responsible for
+ * verifying that the contents are sane.
+ *
+ * returns offset of FMAP signature to indicate success
+ * returns <0 to indicate failure
+ */
+INTN
+EFIAPI
+FmapFind (
+  CONST UINT8 *Image,
+  UINTN Len
+  );
+
+/*
+ * fmap_size - returns size of fmap data structure (including areas)
+ *
+ * @Map:  fmap
+ *
+ * returns size of fmap structure if successful
+ * returns <0 to indicate failure
+ */
+INTN
+EFIAPI
+FmapSize (
+  IN CONST Fmap *Map
+  );
+
+/*
+ * FmapFindArea - find an fmap_area entry (by name) and return pointer to it
+ *
+ * @Map:  fmap structure to parse
+ * @Name: name of area to find
+ *
+ * returns a pointer to the entry in the fmap structure if successful
+ * returns NULL to indicate failure or if no matching area entry is found
+ */
+CONST FmapArea *
+EFIAPI
+FmapFindArea (
+  IN CONST Fmap *Map,
+  IN CONST CHAR8 *Name
+);
+
+#endif  /* FLASHMAP_LIB_FMAP_H__*/

--- a/DasharoPayloadPkg/Library/CbfsLib/CbfsLib.inf
+++ b/DasharoPayloadPkg/Library/CbfsLib/CbfsLib.inf
@@ -1,0 +1,34 @@
+## @file
+#  coreboot file-system management library.
+#
+#  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = CbfsLib
+  FILE_GUID                      = B531AC59-411A-4359-B60E-610E28DADF70
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CbfsLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  cbfs_image.c
+  common.c
+  xdr.c
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib

--- a/DasharoPayloadPkg/Library/CbfsLib/adapt.h
+++ b/DasharoPayloadPkg/Library/CbfsLib/adapt.h
@@ -1,0 +1,39 @@
+#ifndef ADAPT_H__
+#define ADAPT_H__
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+typedef UINTN size_t;
+typedef INTN ptrdiff_t;
+typedef UINT8 uint8_t;
+typedef UINT16 uint16_t;
+typedef UINT32 uint32_t;
+typedef UINT64 uint64_t;
+typedef INT8 int8_t;
+typedef INT16 int16_t;
+typedef INT32 int32_t;
+typedef INT64 int64_t;
+typedef BOOLEAN bool;
+
+#define assert(x) ASSERT (x)
+#define memcmp(a, b, l) CompareMem ((a), (b), (l))
+#define memcpy(a, b, l) CopyMem ((a), (b), (l))
+#define memmove(a, b, l) CopyMem ((a), (b), (l))
+#define memset(b, v, l) SetMem ((b), (l), (v))
+#define strcpy(d, s) AsciiStrCpyS ((d), AsciiStrSize (s), (s))
+#define strlen(s) AsciiStrLen (s)
+#define strcasecmp(s, t) AsciiStriCmp ((s), (t))
+#define malloc(s) AllocatePool (s)
+#define free(p) FreePool (p)
+
+#define false FALSE
+#define true TRUE
+
+#define ERROR(...) DEBUG ((DEBUG_ERROR, __VA_ARGS__))
+#define INFO(...) DEBUG ((DEBUG_INFO, __VA_ARGS__))
+#define WARN(...) DEBUG ((DEBUG_WARN, __VA_ARGS__))
+
+#endif /* ADAPT_H__ */

--- a/DasharoPayloadPkg/Library/CbfsLib/cbfs.h
+++ b/DasharoPayloadPkg/Library/CbfsLib/cbfs.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef __CBFS_H
+#define __CBFS_H
+
+#include "cbfs_serialized.h"
+
+/* To make CBFS more friendly to ROM, fill -1 (0xFF) instead of zero. */
+#define CBFS_CONTENT_DEFAULT_VALUE	(-1)
+
+#define CBFS_SUBHEADER(_p) ( (void *) ((((uint8_t *) (_p)) + ntohl((_p)->offset))) )
+
+#endif

--- a/DasharoPayloadPkg/Library/CbfsLib/cbfs_image.c
+++ b/DasharoPayloadPkg/Library/CbfsLib/cbfs_image.c
@@ -1,0 +1,511 @@
+/* CBFS Image Manipulation */
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include "common.h"
+#include "cbfs_image.h"
+
+/* Even though the file-adding functions---cbfs_add_entry() and
+ * cbfs_add_entry_at()---perform their sizing checks against the beginning of
+ * the subsequent section rather than a stable recorded value such as an empty
+ * file header's len field, it's possible to prove two interesting properties
+ * about their behavior:
+ *  - Placing a new file within an empty entry located below an existing file
+ *    entry will never leave an aligned flash address containing neither the
+ *    beginning of a file header nor part of a file.
+ *  - Placing a new file in an empty entry at the very end of the image such
+ *    that it fits, but leaves no room for a final header, is guaranteed not to
+ *    change the total amount of space for entries, even if that new file is
+ *    later removed from the CBFS.
+ * These properties are somewhat nonobvious from the implementation, so the
+ * reader is encouraged to blame this comment and examine the full proofs
+ * in the commit message before making significant changes that would risk
+ * removing said guarantees.
+ */
+
+/* CBFS image */
+
+size_t cbfs_calculate_file_header_size(const char *name)
+{
+	return (sizeof(struct cbfs_file) +
+		align_up(strlen(name) + 1, CBFS_ATTRIBUTE_ALIGN));
+}
+
+/* Only call on legacy CBFSes possessing a master header. */
+static int cbfs_fix_legacy_size(struct cbfs_image *image, char *hdr_loc)
+{
+	assert(image);
+	assert(cbfs_is_legacy_cbfs(image));
+	// A bug in old cbfstool may produce extra few bytes (by alignment) and
+	// cause cbfstool to overwrite things after free space -- which is
+	// usually CBFS header on x86. We need to workaround that.
+	// Except when we run across a file that contains the actual header,
+	// in which case this image is a safe, new-style
+	// `cbfstool add-master-header` based image.
+
+	struct cbfs_file *entry, *first = NULL, *last = NULL;
+	for (first = entry = cbfs_find_first_entry(image);
+	     entry && cbfs_is_valid_entry(image, entry);
+	     entry = cbfs_find_next_entry(image, entry)) {
+		/* Is the header guarded by a CBFS file entry? Then exit */
+		if (((char *)entry) + ntohl(entry->offset) == hdr_loc) {
+			return 0;
+		}
+		last = entry;
+	}
+	if ((char *)first < (char *)hdr_loc &&
+	    (char *)entry > (char *)hdr_loc) {
+		WARN("CBFS image was created with old cbfstool with size bug. "
+		     "Fixing size in last entry...\n");
+		last->len = htonl(ntohl(last->len) - image->header.align);
+	}
+	return 0;
+}
+
+void cbfs_get_header(struct cbfs_header *header, void *src)
+{
+	struct buffer outheader;
+
+	outheader.data = src;	/* We're not modifying the data */
+	outheader.size = 0;
+
+	header->magic = xdr_be.get32(&outheader);
+	header->version = xdr_be.get32(&outheader);
+	header->romsize = xdr_be.get32(&outheader);
+	header->bootblocksize = xdr_be.get32(&outheader);
+	header->align = xdr_be.get32(&outheader);
+	header->offset = xdr_be.get32(&outheader);
+	header->architecture = xdr_be.get32(&outheader);
+}
+
+int cbfs_image_from_buffer(struct cbfs_image *out, struct buffer *in,
+			   uint32_t offset)
+{
+	assert(out);
+	assert(in);
+	assert(in->data);
+
+	buffer_clone(&out->buffer, in);
+	out->has_header = false;
+
+	if (cbfs_is_valid_cbfs(out)) {
+		return 0;
+	}
+
+	void *header_loc = cbfs_find_header(in->data, in->size, offset);
+	if (header_loc) {
+		cbfs_get_header(&out->header, header_loc);
+		out->has_header = true;
+		cbfs_fix_legacy_size(out, header_loc);
+		return 0;
+	} else if (offset != HEADER_OFFSET_UNKNOWN) {
+		ERROR("The -H switch is only valid on legacy images having CBFS master headers.\n");
+	}
+	ERROR("Selected image region is not a valid CBFS.\n");
+	return 1;
+}
+
+/* Tries to add an entry with its data (CBFS_SUBHEADER) at given offset. */
+static int cbfs_add_entry_at(struct cbfs_image *image,
+			     struct cbfs_file *entry,
+			     const void *data,
+			     uint32_t content_offset,
+			     const struct cbfs_file *header,
+			     const size_t len_align)
+{
+	struct cbfs_file *next = cbfs_find_next_entry(image, entry);
+	uint32_t addr = cbfs_get_entry_addr(image, entry),
+		 addr_next = cbfs_get_entry_addr(image, next);
+	uint32_t min_entry_size = cbfs_calculate_file_header_size("");
+	uint32_t len, header_offset;
+	uint32_t align = image->has_header ? image->header.align :
+							CBFS_ALIGNMENT;
+	uint32_t header_size = ntohl(header->offset);
+
+	header_offset = content_offset - header_size;
+	if (header_offset % align)
+		header_offset -= header_offset % align;
+	if (header_offset < addr) {
+		ERROR("No space to hold cbfs_file header.");
+		return -1;
+	}
+
+	// Process buffer BEFORE content_offset.
+	if (header_offset - addr > min_entry_size) {
+		len = header_offset - addr - min_entry_size;
+		if (cbfs_create_empty_entry(entry, CBFS_TYPE_NULL, len, ""))
+			return -1;
+		entry = cbfs_find_next_entry(image, entry);
+		addr = cbfs_get_entry_addr(image, entry);
+	}
+
+	len = content_offset - addr - header_size;
+	memcpy(entry, header, header_size);
+	if (len != 0) {
+		/*
+		 * The header moved backwards a bit to accommodate cbfs_file
+		 * alignment requirements, so patch up ->offset to still point
+		 * to file data. Move attributes forward so the end of the
+		 * attribute list still matches the end of the metadata.
+		 */
+		uint32_t offset = ntohl(entry->offset);
+		uint32_t attrs = ntohl(entry->attributes_offset);
+		if (attrs == 0) {
+			memset((uint8_t *)entry + offset, 0, len);
+		} else {
+			uint8_t *p = (uint8_t *)entry + attrs;
+			memmove(p + len, p, offset - attrs);
+			memset(p, 0, len);
+			attrs += len;
+			entry->attributes_offset = htonl(attrs);
+		}
+		offset += len;
+		entry->offset = htonl(offset);
+	}
+
+	// Ready to fill data into entry.
+	assert((char*)CBFS_SUBHEADER(entry) - image->buffer.data ==
+	       (ptrdiff_t)content_offset);
+	memcpy(CBFS_SUBHEADER(entry), data, ntohl(entry->len));
+
+	// Align the length to a multiple of len_align
+	if (len_align &&
+	    ((ntohl(entry->offset) + ntohl(entry->len)) % len_align)) {
+		size_t off = (ntohl(entry->offset) + ntohl(entry->len)) % len_align;
+		entry->len = htonl(ntohl(entry->len) + len_align - off);
+	}
+
+	// Process buffer AFTER entry.
+	entry = cbfs_find_next_entry(image, entry);
+	addr = cbfs_get_entry_addr(image, entry);
+	if (addr == addr_next)
+		return 0;
+
+	assert(addr < addr_next);
+	if (addr_next - addr < min_entry_size) {
+		/* No need to increase the size of the just
+		 * stored file to extend to next file. Alignment
+		 * of next file takes care of this.
+		 */
+		return 0;
+	}
+
+	len = addr_next - addr - min_entry_size;
+	/* keep space for master header pointer */
+	if ((uint8_t *)entry + min_entry_size + len >
+			(uint8_t *)buffer_get(&image->buffer) +
+			buffer_size(&image->buffer) - sizeof(int32_t)) {
+		len -= sizeof(int32_t);
+	}
+	if (cbfs_create_empty_entry(entry, CBFS_TYPE_NULL, len, ""))
+		return -1;
+	return 0;
+}
+
+int cbfs_add_entry(struct cbfs_image *image, struct buffer *buffer,
+		   uint32_t content_offset,
+		   struct cbfs_file *header,
+		   const size_t len_align)
+{
+	assert(image);
+	assert(buffer);
+	assert(buffer->data);
+	assert(!IS_HOST_SPACE_ADDRESS(content_offset));
+
+	const char *name = header->filename;
+
+	/* This is so special rows in cbfstool print -k -v output stay unambiguous. */
+	if (name[0] == '[') {
+		ERROR("CBFS file name `%s` must not start with `[`\n", name);
+		return -1;
+	}
+
+	uint32_t entry_type;
+	uint32_t addr, addr_next;
+	uint32_t entry_size;
+	uint32_t max_null_entry_size = 0;
+	struct cbfs_file *entry, *next;
+	uint32_t need_size;
+	uint32_t header_size = ntohl(header->offset);
+
+	need_size = header_size + buffer->size;
+
+	// Merge empty entries.
+	cbfs_legacy_walk(image, cbfs_merge_empty_entry, NULL);
+
+	for (entry = cbfs_find_first_entry(image);
+	     entry && cbfs_is_valid_entry(image, entry);
+	     entry = cbfs_find_next_entry(image, entry)) {
+
+		entry_type = ntohl(entry->type);
+		if (entry_type != CBFS_TYPE_NULL)
+			continue;
+
+		addr = cbfs_get_entry_addr(image, entry);
+		next = cbfs_find_next_entry(image, entry);
+		addr_next = cbfs_get_entry_addr(image, next);
+		entry_size = addr_next - addr;
+		max_null_entry_size = MAX(max_null_entry_size, entry_size);
+
+		/* Will the file fit? Don't yet worry if we have space for a new
+		 * "empty" entry. We take care of that later.
+		 */
+		if (addr + need_size > addr_next)
+			continue;
+
+		// Test for complicated cases
+		if (content_offset > 0) {
+			if (addr_next < content_offset) {
+				continue;
+			} else if (addr > content_offset) {
+				break;
+			} else if (addr + header_size > content_offset) {
+				ERROR("Not enough space for header.\n");
+				break;
+			} else if (content_offset + buffer->size > addr_next) {
+				ERROR("Not enough space for content.\n");
+				break;
+			}
+		}
+
+		// TODO there are more few tricky cases that we may
+		// want to fit by altering offset.
+
+		if (content_offset == 0) {
+			// we tested every condition earlier under which
+			// placing the file there might fail
+			content_offset = addr + header_size;
+		}
+
+		if (cbfs_add_entry_at(image, entry, buffer->data,
+				      content_offset, header, len_align) == 0) {
+			return 0;
+		}
+		break;
+	}
+
+	ERROR("Could not add %s [header %d + content %zd bytes (%zd KB)] @0x%x; "
+	      "Largest empty slot: %d bytes\n",
+	      buffer->name, header_size, buffer->size, buffer->size / 1024, content_offset,
+	      max_null_entry_size);
+	return -1;
+}
+
+struct cbfs_file *cbfs_get_entry(struct cbfs_image *image, const char *name)
+{
+	struct cbfs_file *entry;
+	for (entry = cbfs_find_first_entry(image);
+	     entry && cbfs_is_valid_entry(image, entry);
+	     entry = cbfs_find_next_entry(image, entry)) {
+		if (strcasecmp(entry->filename, name) == 0) {
+			return entry;
+		}
+	}
+	return NULL;
+}
+
+int cbfs_remove_entry(struct cbfs_image *image, const char *name)
+{
+	struct cbfs_file *entry;
+	entry = cbfs_get_entry(image, name);
+	if (!entry) {
+		ERROR("CBFS file %s not found.\n", name);
+		return -1;
+	}
+	entry->type = htonl(CBFS_TYPE_DELETED);
+	cbfs_legacy_walk(image, cbfs_merge_empty_entry, NULL);
+	return 0;
+}
+
+int cbfs_merge_empty_entry(struct cbfs_image *image, struct cbfs_file *entry,
+			   unused void *arg)
+{
+	struct cbfs_file *next;
+	uint32_t next_addr = 0;
+
+	/* We don't return here even if this entry is already empty because we
+	   want to merge the empty entries following after it. */
+
+	/* Loop until non-empty entry is found, starting from the current entry.
+	   After the loop, next_addr points to the next non-empty entry. */
+	next = entry;
+	while (ntohl(next->type) == CBFS_TYPE_DELETED ||
+			ntohl(next->type) == CBFS_TYPE_NULL) {
+		next = cbfs_find_next_entry(image, next);
+		if (!next)
+			break;
+		next_addr = cbfs_get_entry_addr(image, next);
+		if (!cbfs_is_valid_entry(image, next))
+			/* 'next' could be the end of cbfs */
+			break;
+	}
+
+	if (!next_addr)
+		/* Nothing to empty */
+		return 0;
+
+	/* We can return here if we find only a single empty entry.
+	   For simplicity, we just proceed (and make it empty again). */
+
+	/* We're creating one empty entry for combined empty spaces */
+	uint32_t addr = cbfs_get_entry_addr(image, entry);
+	size_t len = next_addr - addr - cbfs_calculate_file_header_size("");
+	return cbfs_create_empty_entry(entry, CBFS_TYPE_NULL, len, "");
+}
+
+int cbfs_legacy_walk(struct cbfs_image *image, cbfs_entry_callback callback,
+	      void *arg)
+{
+	int count = 0;
+	struct cbfs_file *entry;
+	for (entry = cbfs_find_first_entry(image);
+	     entry && cbfs_is_valid_entry(image, entry);
+	     entry = cbfs_find_next_entry(image, entry)) {
+		count ++;
+		if (callback(image, entry, arg) != 0)
+			break;
+	}
+	return count;
+}
+
+static int cbfs_header_valid(struct cbfs_header *header)
+{
+	if ((ntohl(header->magic) == CBFS_HEADER_MAGIC) &&
+	    ((ntohl(header->version) == CBFS_HEADER_VERSION1) ||
+	     (ntohl(header->version) == CBFS_HEADER_VERSION2)) &&
+	    (ntohl(header->offset) < ntohl(header->romsize)))
+		return 1;
+	return 0;
+}
+
+struct cbfs_header *cbfs_find_header(char *data, size_t size,
+				     uint32_t forced_offset)
+{
+	size_t offset;
+	int found = 0;
+	int32_t rel_offset;
+	struct cbfs_header *header, *result = NULL;
+
+	if (forced_offset < (size - sizeof(struct cbfs_header))) {
+		/* Check if the forced header is valid. */
+		header = (struct cbfs_header *)(data + forced_offset);
+		if (cbfs_header_valid(header))
+			return header;
+		return NULL;
+	}
+
+	// Try finding relative offset of master header at end of file first.
+	rel_offset = *(int32_t *)(data + size - sizeof(int32_t));
+	offset = size + rel_offset;
+
+	if (offset >= size - sizeof(*header) ||
+	    !cbfs_header_valid((struct cbfs_header *)(data + offset))) {
+		// Some use cases append non-CBFS data to the end of the ROM.
+		offset = 0;
+	}
+
+	for (; offset + sizeof(*header) < size; offset++) {
+		header = (struct cbfs_header *)(data + offset);
+		if (!cbfs_header_valid(header))
+			continue;
+		if (!found++)
+			result = header;
+	}
+	if (found > 1)
+		// Top-aligned images usually have a working relative offset
+		// field, so this is more likely to happen on bottom-aligned
+		// ones (where the first header is the "outermost" one)
+		WARN("Multiple (%d) CBFS headers found, using the first one.\n",
+		       found);
+	return result;
+}
+
+
+struct cbfs_file *cbfs_find_first_entry(struct cbfs_image *image)
+{
+	assert(image);
+	if (image->has_header)
+		/* header.offset is relative to start of flash, not
+		 * start of region, so use it with the full image.
+		 */
+		return (struct cbfs_file *)
+			(buffer_get_original_backing(&image->buffer) +
+			image->header.offset);
+	else
+		return (struct cbfs_file *)buffer_get(&image->buffer);
+}
+
+struct cbfs_file *cbfs_find_next_entry(struct cbfs_image *image,
+				       struct cbfs_file *entry)
+{
+	uint32_t addr = cbfs_get_entry_addr(image, entry);
+	int align = image->has_header ? image->header.align : CBFS_ALIGNMENT;
+	assert(entry && cbfs_is_valid_entry(image, entry));
+	addr += ntohl(entry->offset) + ntohl(entry->len);
+	addr = align_up(addr, align);
+	return (struct cbfs_file *)(image->buffer.data + addr);
+}
+
+uint32_t cbfs_get_entry_addr(struct cbfs_image *image, struct cbfs_file *entry)
+{
+	assert(image && image->buffer.data && entry);
+	return (int32_t)((char *)entry - image->buffer.data);
+}
+
+int cbfs_is_valid_cbfs(struct cbfs_image *image)
+{
+	return buffer_check_magic(&image->buffer, CBFS_FILE_MAGIC,
+						strlen(CBFS_FILE_MAGIC));
+}
+
+int cbfs_is_legacy_cbfs(struct cbfs_image *image)
+{
+	return image->has_header;
+}
+
+int cbfs_is_valid_entry(struct cbfs_image *image, struct cbfs_file *entry)
+{
+	uint32_t offset = cbfs_get_entry_addr(image, entry);
+
+	if (offset >= image->buffer.size)
+		return 0;
+
+	struct buffer entry_data;
+	buffer_clone(&entry_data, &image->buffer);
+	buffer_seek(&entry_data, offset);
+	return buffer_check_magic(&entry_data, CBFS_FILE_MAGIC,
+						strlen(CBFS_FILE_MAGIC));
+}
+
+struct cbfs_file *cbfs_create_file_header(int type,
+			    size_t len, const char *name)
+{
+	size_t header_size = cbfs_calculate_file_header_size(name);
+	if (header_size > CBFS_METADATA_MAX_SIZE) {
+		ERROR("'%s' name too long to fit in CBFS header\n", name);
+		return NULL;
+	}
+
+	struct cbfs_file *entry = malloc(CBFS_METADATA_MAX_SIZE);
+	memset(entry, CBFS_CONTENT_DEFAULT_VALUE, CBFS_METADATA_MAX_SIZE);
+	memcpy(entry->magic, CBFS_FILE_MAGIC, sizeof(entry->magic));
+	entry->type = htonl(type);
+	entry->len = htonl(len);
+	entry->attributes_offset = 0;
+	entry->offset = htonl(header_size);
+	memset(entry->filename, 0, ntohl(entry->offset) - sizeof(*entry));
+	strcpy(entry->filename, name);
+	return entry;
+}
+
+int cbfs_create_empty_entry(struct cbfs_file *entry, int type,
+			    size_t len, const char *name)
+{
+	struct cbfs_file *tmp = cbfs_create_file_header(type, len, name);
+	if (!tmp)
+		return -1;
+
+	memcpy(entry, tmp, ntohl(tmp->offset));
+	free(tmp);
+	memset(CBFS_SUBHEADER(entry), CBFS_CONTENT_DEFAULT_VALUE, len);
+	return 0;
+}

--- a/DasharoPayloadPkg/Library/CbfsLib/cbfs_image.h
+++ b/DasharoPayloadPkg/Library/CbfsLib/cbfs_image.h
@@ -1,0 +1,108 @@
+/* CBFS Image Manipulation */
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef __CBFS_IMAGE_H
+#define __CBFS_IMAGE_H
+
+#include "common.h"
+#include "cbfs.h"
+
+#define HEADER_OFFSET_UNKNOWN (~0u)
+
+/* CBFS image processing */
+
+struct cbfs_image {
+	struct buffer buffer;
+	/* An image has a header iff it's a legacy CBFS. */
+	bool has_header;
+	/* Only meaningful if has_header is selected. */
+	struct cbfs_header header;
+};
+
+/* Or deserialize into host-native format */
+void cbfs_get_header(struct cbfs_header *header, void *src);
+
+/* Constructs a cbfs_image from a buffer. The resulting image contains a shallow
+ * copy of the buffer; releasing either one is the legal way to clean up after
+ * both of them at once. Always produces a cbfs_image, but...
+ * Returns 0 if it contains a valid CBFS, non-zero if it's unrecognized data. */
+int cbfs_image_from_buffer(struct cbfs_image *out, struct buffer *in,
+			   uint32_t offset);
+
+/* Returns a pointer to entry by name, or NULL if name is not found. */
+struct cbfs_file *cbfs_get_entry(struct cbfs_image *image, const char *name);
+
+/* Adds an entry to CBFS image by given name and type. If content_offset is
+ * non-zero, try to align "content" (CBFS_SUBHEADER(p)) at content_offset.
+ * Never pass this function a top-aligned address: convert it to an offset.
+ * Returns 0 on success, otherwise non-zero. */
+int cbfs_add_entry(struct cbfs_image *image, struct buffer *buffer,
+		   uint32_t content_offset, struct cbfs_file *header,
+		   const size_t len_align);
+
+/* Removes an entry from CBFS image. Returns 0 on success, otherwise non-zero. */
+int cbfs_remove_entry(struct cbfs_image *image, const char *name);
+
+/* Create a new cbfs file header structure to work with.
+   Returns newly allocated memory that the caller needs to free after use. */
+struct cbfs_file *cbfs_create_file_header(int type, size_t len,
+	const char *name);
+
+/* Initializes a new empty (type = NULL) entry with size and name in CBFS image.
+ * Returns 0 on success, otherwise (ex, not found) non-zero. */
+int cbfs_create_empty_entry(struct cbfs_file *entry, int type,
+			    size_t len, const char *name);
+
+/* Callback function used by cbfs_legacy_walk.
+ * Returns 0 on success, or non-zero to stop further iteration. */
+typedef int (*cbfs_entry_callback)(struct cbfs_image *image,
+				   struct cbfs_file *file,
+				   void *arg);
+
+/* Iterates through all entries in CBFS image, and invoke with callback.
+ * Stops if callback returns non-zero values. Unlike the commonlib cbfs_walk(),
+ * this can deal with different alignments in legacy CBFS (with master header).
+ * Returns number of entries invoked. */
+int cbfs_legacy_walk(struct cbfs_image *image, cbfs_entry_callback callback,
+		     void *arg);
+
+/* Primitive CBFS utilities */
+
+/* Returns a pointer to the only valid CBFS header in give buffer, otherwise
+ * NULL (including when multiple headers were found). If there is a X86 ROM
+ * style signature (pointer at 0xfffffffc) found in ROM, it will be selected as
+ * the only header.*/
+struct cbfs_header *cbfs_find_header(char *data, size_t size,
+				     uint32_t forced_offset);
+
+/* Returns the first cbfs_file entry in CBFS image by CBFS header (no matter if
+ * the entry has valid content or not), otherwise NULL. */
+struct cbfs_file *cbfs_find_first_entry(struct cbfs_image *image);
+
+/* Returns next cbfs_file entry (no matter if its content is valid or not), or
+ * NULL on failure. */
+struct cbfs_file *cbfs_find_next_entry(struct cbfs_image *image,
+				       struct cbfs_file *entry);
+
+/* Returns ROM address (offset) of entry.
+ * This is different from entry->offset (pointer to content). */
+uint32_t cbfs_get_entry_addr(struct cbfs_image *image, struct cbfs_file *entry);
+
+/* Returns 1 if valid new-format CBFS (without a master header), otherwise 0. */
+int cbfs_is_valid_cbfs(struct cbfs_image *image);
+
+/* Returns 1 if valid legacy CBFS (with a master header), otherwise 0. */
+int cbfs_is_legacy_cbfs(struct cbfs_image *image);
+
+/* Returns 1 if entry has valid data (by checking magic number), otherwise 0. */
+int cbfs_is_valid_entry(struct cbfs_image *image, struct cbfs_file *entry);
+
+/* Merge empty entries starting from given entry.
+ * Returns 0 on success, otherwise non-zero. */
+int cbfs_merge_empty_entry(struct cbfs_image *image, struct cbfs_file *entry,
+			   void *arg);
+
+/* Returns the size of a cbfs file header with no extensions */
+size_t cbfs_calculate_file_header_size(const char *name);
+
+#endif

--- a/DasharoPayloadPkg/Library/CbfsLib/cbfs_serialized.h
+++ b/DasharoPayloadPkg/Library/CbfsLib/cbfs_serialized.h
@@ -1,0 +1,210 @@
+/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only */
+
+#ifndef _CBFS_SERIALIZED_H_
+#define _CBFS_SERIALIZED_H_
+
+#include "adapt.h"
+
+#ifdef __packed
+#undef __packed
+#endif
+
+#define __packed __attribute__((packed))
+
+enum cbfs_compression {
+	CBFS_COMPRESS_NONE	= 0,
+	CBFS_COMPRESS_LZMA	= 1,
+	CBFS_COMPRESS_LZ4	= 2,
+};
+
+enum cbfs_type {
+	/* QUERY is an alias for DELETED that can be passed to CBFS APIs to
+	   inquire about the type of a file, rather than constrain it. */
+	CBFS_TYPE_QUERY		= 0,
+	CBFS_TYPE_DELETED	= 0x00000000,
+	CBFS_TYPE_NULL		= 0xffffffff,
+	CBFS_TYPE_BOOTBLOCK	= 0x01,
+	CBFS_TYPE_CBFSHEADER	= 0x02,
+	CBFS_TYPE_LEGACY_STAGE	= 0x10,
+	CBFS_TYPE_STAGE		= 0x11,
+	CBFS_TYPE_SELF		= 0x20,
+	CBFS_TYPE_FIT_PAYLOAD	= 0x21,
+	CBFS_TYPE_OPTIONROM	= 0x30,
+	CBFS_TYPE_BOOTSPLASH	= 0x40,
+	CBFS_TYPE_RAW		= 0x50,
+	CBFS_TYPE_VSA		= 0x51,
+	CBFS_TYPE_MBI		= 0x52,
+	CBFS_TYPE_MICROCODE	= 0x53,
+	CBFS_TYPE_INTEL_FIT	= 0x54,
+	CBFS_TYPE_FSP		= 0x60,
+	CBFS_TYPE_MRC		= 0x61,
+	CBFS_TYPE_MMA		= 0x62,
+	CBFS_TYPE_EFI		= 0x63,
+	CBFS_TYPE_STRUCT	= 0x70,
+	CBFS_TYPE_AMDFW         = 0x80,
+	CBFS_TYPE_CMOS_DEFAULT	= 0xaa,
+	CBFS_TYPE_SPD		= 0xab,
+	CBFS_TYPE_MRC_CACHE	= 0xac,
+	CBFS_TYPE_CMOS_LAYOUT	= 0x01aa,
+};
+
+#define CBFS_HEADER_MAGIC  0x4F524243		/* BE: 'ORBC' */
+#define CBFS_HEADER_VERSION1 0x31313131		/* BE: '1111' */
+#define CBFS_HEADER_VERSION2 0x31313132		/* BE: '1112' */
+#define CBFS_HEADER_VERSION  CBFS_HEADER_VERSION2
+
+/* this is the master cbfs header - it must be located somewhere available
+ * to bootblock (to load romstage). The last 4 bytes in the image contain its
+ * relative offset from the end of the image (as a 32-bit signed integer). */
+
+struct cbfs_header {
+	uint32_t magic;
+	uint32_t version;
+	uint32_t romsize;
+	uint32_t bootblocksize;
+	uint32_t align; /* fixed to 64 bytes */
+	uint32_t offset;
+	uint32_t architecture;
+	uint32_t pad[1];
+} __packed;
+
+/* this used to be flexible, but wasn't ever set to something different. */
+#define CBFS_ALIGNMENT 64
+
+/* "Unknown" refers to CBFS headers version 1,
+ * before the architecture was defined (i.e., x86 only).
+ */
+enum cbfs_architecture {
+	CBFS_ARCHITECTURE_UNKNOWN  = 0xFFFFFFFF,
+	CBFS_ARCHITECTURE_X86      = 0x00000001,
+	CBFS_ARCHITECTURE_ARM      = 0x00000010,
+	CBFS_ARCHITECTURE_AARCH64  = 0x0000aa64,
+	CBFS_ARCHITECTURE_MIPS     = 0x00000100,	/* deprecated */
+	CBFS_ARCHITECTURE_RISCV    = 0xc001d0de,
+	CBFS_ARCHITECTURE_PPC64    = 0x407570ff,
+};
+
+/** This is a component header - every entry in the CBFS
+    will have this header.
+
+    This is how the component is arranged in the ROM:
+
+    --------------   <- 0
+    component header
+    --------------   <- sizeof(struct component)
+    component name
+    --------------   <- offset
+    data
+    ...
+    --------------   <- offset + len
+*/
+
+#define CBFS_FILE_MAGIC "LARCHIVE"
+#define CBFS_METADATA_MAX_SIZE 256
+
+struct cbfs_file {
+	char magic[8];
+	uint32_t len;
+	uint32_t type;
+	uint32_t attributes_offset;
+	uint32_t offset;
+	char filename[];
+} __packed;
+
+#if defined __GNUC__ && (__GNUC__ * 100 + __GNUC_MINOR__) >= 406
+_Static_assert(sizeof(struct cbfs_file) == 24, "cbfs_file size mismatch");
+#endif
+
+/* The common fields of extended cbfs file attributes.
+   Attributes are expected to start with tag/len, then append their
+   specific fields. */
+struct cbfs_file_attribute {
+	uint32_t tag;
+	/* len covers the whole structure, incl. tag and len */
+	uint32_t len;
+	uint8_t data[];
+} __packed;
+
+/* All attribute sizes must be divisible by this! */
+#define CBFS_ATTRIBUTE_ALIGN 4
+
+/* Depending on how the header was initialized, it may be backed with 0x00 or
+ * 0xff. Support both. */
+enum cbfs_file_attr_tag {
+	CBFS_FILE_ATTR_TAG_UNUSED	= 0,
+	CBFS_FILE_ATTR_TAG_UNUSED2	= 0xffffffff,
+	CBFS_FILE_ATTR_TAG_COMPRESSION	= 0x42435a4c, /* BE: 'BCZL' */
+	CBFS_FILE_ATTR_TAG_HASH		= 0x68736148, /* BE: 'hsaH' */
+	CBFS_FILE_ATTR_TAG_POSITION	= 0x42435350, /* BE: 'BCSP' */
+	CBFS_FILE_ATTR_TAG_ALIGNMENT	= 0x42434c41, /* BE: 'BCLA' */
+	CBFS_FILE_ATTR_TAG_IBB		= 0x32494242, /* BE: '2IBB' */
+	CBFS_FILE_ATTR_TAG_PADDING	= 0x47444150, /* BE: 'GNDP' */
+	CBFS_FILE_ATTR_TAG_STAGEHEADER	= 0x53746748, /* BE: 'StgH' */
+};
+
+struct cbfs_file_attr_compression {
+	uint32_t tag;
+	uint32_t len;
+	/* whole file compression format. 0 if no compression. */
+	uint32_t compression;
+	uint32_t decompressed_size;
+} __packed;
+
+struct cbfs_file_attr_position {
+	uint32_t tag;
+	uint32_t len;
+	uint32_t position;
+} __packed;
+
+struct cbfs_file_attr_align {
+	uint32_t tag;
+	uint32_t len;
+	uint32_t alignment;
+} __packed;
+
+struct cbfs_file_attr_stageheader {
+	uint32_t tag;
+	uint32_t len;
+	uint64_t loadaddr;	/* Memory address to load the code to. */
+	uint32_t entry_offset;	/* Offset of entry point from loadaddr. */
+	uint32_t memlen;	/* Total length (including BSS) in memory. */
+} __packed;
+
+
+/*** Component sub-headers ***/
+
+/* Following are component sub-headers for the "standard"
+   component types */
+
+/** this is the sub-header for payload components.  Payloads
+    are loaded by coreboot at the end of the boot process */
+
+struct cbfs_payload_segment {
+	uint32_t type;
+	uint32_t compression;
+	uint32_t offset;
+	uint64_t load_addr;
+	uint32_t len;
+	uint32_t mem_len;
+} __packed;
+
+struct cbfs_payload {
+	struct cbfs_payload_segment segments;
+};
+
+enum cbfs_payload_segment_type {
+	PAYLOAD_SEGMENT_CODE   = 0x434F4445,	/* BE: 'CODE' */
+	PAYLOAD_SEGMENT_DATA   = 0x44415441,	/* BE: 'DATA' */
+	PAYLOAD_SEGMENT_BSS    = 0x42535320,	/* BE: 'BSS ' */
+	PAYLOAD_SEGMENT_ENTRY  = 0x454E5452,	/* BE: 'ENTR' */
+
+	/* PARAMS for PAYLOAD_INFO feature. Broken since 2012, removed 2024. */
+	PAYLOAD_SEGMENT_DEPRECATED_PARAMS = 0x50415241, /* BE: 'PARA' */
+};
+
+struct cbfs_optionrom {
+	uint32_t compression;
+	uint32_t len;
+} __packed;
+
+#endif /* _CBFS_SERIALIZED_H_ */

--- a/DasharoPayloadPkg/Library/CbfsLib/common.c
+++ b/DasharoPayloadPkg/Library/CbfsLib/common.c
@@ -1,0 +1,16 @@
+/* common utility functions for cbfstool */
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include "common.h"
+#include "cbfs.h"
+
+/* Small, OS/libc independent runtime check for endianness */
+int is_big_endian(void)
+{
+	static const uint32_t inttest = 0x12345678;
+	const uint8_t inttest_lsb = *(const uint8_t *)&inttest;
+	if (inttest_lsb == 0x12) {
+		return 1;
+	}
+	return 0;
+}

--- a/DasharoPayloadPkg/Library/CbfsLib/common.h
+++ b/DasharoPayloadPkg/Library/CbfsLib/common.h
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef __CBFSTOOL_COMMON_H
+#define __CBFSTOOL_COMMON_H
+
+#include "adapt.h"
+
+#include "cbfs_serialized.h"
+#include "swab.h"
+
+/*
+ * There are two address spaces that this tool deals with - SPI flash address space and host
+ * address space. This macros checks if the address is greater than 2GiB under the assumption
+ * that the low MMIO lives in the top half of the 4G address space of the host.
+ */
+#define IS_HOST_SPACE_ADDRESS(addr)	((uint32_t)(addr) > 0x80000000)
+
+// #define ERROR(...) do { fprintf(stderr, __VA_ARGS__); } while(0)
+// #define INFO(...) do { fprintf(stderr, __VA_ARGS__); } while(0)
+// #define WARN(...) do { fprintf(stderr, __VA_ARGS__); } while(0)
+// #define DEBUG(...) do { fprintf(stderr, __VA_ARGS__); } while(0)
+#define LOG(...) do { fprintf(stderr, __VA_ARGS__); } while(0)
+
+#define unused __attribute__((unused))
+
+static inline uint32_t align_up(uint32_t value, uint32_t align)
+{
+	if (value % align)
+		value += align - (value % align);
+	return value;
+}
+
+/* Buffer and file I/O */
+struct buffer {
+	char *name;
+	char *data;
+	size_t offset;
+	size_t size;
+};
+
+static inline void *buffer_get(const struct buffer *b)
+{
+	return b->data;
+}
+
+static inline size_t buffer_size(const struct buffer *b)
+{
+	return b->size;
+}
+
+static inline size_t buffer_offset(const struct buffer *b)
+{
+	return b->offset;
+}
+
+/*
+ * Shrink a buffer toward the beginning of its previous space.
+ * Afterward, buffer_delete() remains the means of cleaning it up. */
+static inline void buffer_set_size(struct buffer *b, size_t size)
+{
+	b->size = size;
+}
+
+/* Initialize a buffer with the given constraints. */
+static inline void buffer_init(struct buffer *b, char *name, void *data,
+                               size_t size)
+{
+	b->name = name;
+	b->data = data;
+	b->size = size;
+	b->offset = 0;
+}
+
+/* Splice a buffer into another buffer. Note that it's up to the caller to
+ * bounds check the offset and size. The resulting buffer is backed by the same
+ * storage as the original, so although it is valid to buffer_delete() either
+ * one of them, doing so releases both simultaneously. */
+static inline void buffer_splice(struct buffer *dest, const struct buffer *src,
+                                 size_t offset, size_t size)
+{
+	dest->name = src->name;
+	dest->data = src->data + offset;
+	dest->offset = src->offset + offset;
+	dest->size = size;
+}
+
+/*
+ * Shallow copy a buffer. To clean up the resources, buffer_delete()
+ * either one, but not both. */
+static inline void buffer_clone(struct buffer *dest, const struct buffer *src)
+{
+	buffer_splice(dest, src, 0, src->size);
+}
+
+/*
+ * Shrink a buffer toward the end of its previous space.
+ * Afterward, buffer_delete() remains the means of cleaning it up. */
+static inline void buffer_seek(struct buffer *b, size_t size)
+{
+	b->offset += size;
+	b->size -= size;
+	b->data += size;
+}
+
+/* Returns whether the buffer begins with the specified magic bytes. */
+static inline bool buffer_check_magic(const struct buffer *b, const char *magic,
+							size_t magic_len)
+{
+	assert(magic);
+	return b && b->size >= magic_len &&
+					memcmp(b->data, magic, magic_len) == 0;
+}
+
+/* Returns the start of the underlying buffer, with the offset undone */
+static inline void *buffer_get_original_backing(const struct buffer *b)
+{
+	if (!b)
+		return NULL;
+	return buffer_get(b) - buffer_offset(b);
+}
+
+/* Loads a file into memory buffer. Returns 0 on success, otherwise non-zero. */
+int buffer_from_file(struct buffer *buffer, const char *filename);
+
+/* Destroys a memory buffer. */
+void buffer_delete(struct buffer *buffer);
+
+/* xdr.c */
+struct xdr {
+	uint8_t (*get8)(struct buffer *input);
+	uint16_t (*get16)(struct buffer *input);
+	uint32_t (*get32)(struct buffer *input);
+	uint64_t (*get64)(struct buffer *input);
+	void (*put8)(struct buffer *input, uint8_t val);
+	void (*put16)(struct buffer *input, uint16_t val);
+	void (*put32)(struct buffer *input, uint32_t val);
+	void (*put64)(struct buffer *input, uint64_t val);
+};
+
+extern struct xdr xdr_be;
+
+#endif

--- a/DasharoPayloadPkg/Library/CbfsLib/swab.h
+++ b/DasharoPayloadPkg/Library/CbfsLib/swab.h
@@ -1,0 +1,56 @@
+#ifndef _SWAB_H
+#define _SWAB_H
+
+/*
+ * linux/byteorder/swab.h
+ * Byte-swapping, independently from CPU endianness
+ *	swabXX[ps]?(foo)
+ *
+ * Francois-Rene Rideau <fare@tunes.org> 19971205
+ *    separated swab functions from cpu_to_XX,
+ *    to clean up support for bizarre-endian architectures.
+ *
+ * See asm-i386/byteorder.h and suches for examples of how to provide
+ * architecture-dependent optimized versions
+ *
+ */
+
+#if !defined(__APPLE__) && !defined(__NetBSD__)
+#define ntohl(x)	(is_big_endian() ? (uint32_t)(x) : swab32(x))
+#define htonl(x)	(is_big_endian() ? (uint32_t)(x) : swab32(x))
+#else
+#include <arpa/inet.h>
+#endif
+#define ntohll(x)	(is_big_endian() ? (uint64_t)(x) : swab64(x))
+#define htonll(x)	(is_big_endian() ? (uint64_t)(x) : swab64(x))
+
+/* casts are necessary for constants, because we never know how for sure
+ * how U/UL/ULL map to __u16, __u32, __u64. At least not in a portable way.
+ */
+#define swab16(x) \
+	((unsigned short)( \
+		(((unsigned short)(x) & (unsigned short)0x00ffU) << 8) | \
+		(((unsigned short)(x) & (unsigned short)0xff00U) >> 8) ))
+
+#define swab32(x) \
+	((unsigned int)( \
+		(((unsigned int)(x) & (unsigned int)0x000000ffUL) << 24) | \
+		(((unsigned int)(x) & (unsigned int)0x0000ff00UL) <<  8) | \
+		(((unsigned int)(x) & (unsigned int)0x00ff0000UL) >>  8) | \
+		(((unsigned int)(x) & (unsigned int)0xff000000UL) >> 24) ))
+
+#define swab64(x) \
+	((uint64_t)( \
+		(((uint64_t)(x) & (uint64_t)0x00000000000000ffULL) << 56) | \
+		(((uint64_t)(x) & (uint64_t)0x000000000000ff00ULL) << 40) | \
+		(((uint64_t)(x) & (uint64_t)0x0000000000ff0000ULL) << 24) | \
+		(((uint64_t)(x) & (uint64_t)0x00000000ff000000ULL) <<  8) | \
+		(((uint64_t)(x) & (uint64_t)0x000000ff00000000ULL) >>  8) | \
+		(((uint64_t)(x) & (uint64_t)0x0000ff0000000000ULL) >> 24) | \
+		(((uint64_t)(x) & (uint64_t)0x00ff000000000000ULL) >> 40) | \
+		(((uint64_t)(x) & (uint64_t)0xff00000000000000ULL) >> 56) ))
+
+/* common.c */
+int is_big_endian(void);
+
+#endif /* _SWAB_H */

--- a/DasharoPayloadPkg/Library/CbfsLib/xdr.c
+++ b/DasharoPayloadPkg/Library/CbfsLib/xdr.c
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include "common.h"
+
+/* The assumption in all this code is that we're given a pointer to enough data.
+ * Hence, we do not check for underflow.
+ */
+static uint8_t get8(struct buffer *input)
+{
+	uint8_t ret = *input->data++;
+	input->size--;
+	return ret;
+}
+
+static uint16_t get16be(struct buffer *input)
+{
+	uint16_t ret;
+	ret = get8(input) << 8;
+	ret |= get8(input);
+	return ret;
+}
+
+static uint32_t get32be(struct buffer *input)
+{
+	uint32_t ret;
+	ret = get16be(input) << 16;
+	ret |= get16be(input);
+	return ret;
+}
+
+static uint64_t get64be(struct buffer *input)
+{
+	uint64_t ret;
+	ret = get32be(input);
+	ret <<= 32;
+	ret |= get32be(input);
+	return ret;
+}
+
+static void put8(struct buffer *input, uint8_t val)
+{
+	input->data[input->size] = val;
+	input->size++;
+}
+
+static void put16be(struct buffer *input, uint16_t val)
+{
+	put8(input, val >> 8);
+	put8(input, val);
+}
+
+static void put32be(struct buffer *input, uint32_t val)
+{
+	put16be(input, val >> 16);
+	put16be(input, val);
+}
+
+static void put64be(struct buffer *input, uint64_t val)
+{
+	put32be(input, val >> 32);
+	put32be(input, val);
+}
+
+struct xdr xdr_be = {
+	get8, get16be, get32be, get64be,
+	put8, put16be, put32be, put64be
+};

--- a/DasharoPayloadPkg/Library/EfiVarsLib/EfiVarsLib.c
+++ b/DasharoPayloadPkg/Library/EfiVarsLib/EfiVarsLib.c
@@ -1,0 +1,246 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent */
+
+#include <Library/EfiVarsLib.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/SmmStoreLib.h>
+
+// Firmware volume is what's stored in SMMSTORE region of CBFS.  It wraps
+// variable store.
+//
+// Variable store is part of firmware volume.  This unit doesn't deal with its
+// header only with data that follows.
+
+STATIC
+UINT16
+CalcChecksum (
+  CONST UINT16 *Hdr,
+  UINTN Size
+  )
+{
+  UINT16  Checksum;
+  UINTN   Idx;
+
+  ASSERT (Size % 2 == 0 && "Header can't have odd length.");
+
+  Checksum = 0;
+  for (Idx = 0; Idx < Size / 2; ++Idx)
+    Checksum += Hdr[Idx];
+
+  return Checksum;
+}
+
+STATIC
+BOOLEAN
+InitFv (
+  IN OUT MemRange  Fv
+  )
+{
+  EFI_STATUS                  Status;
+  UINTN                       BlockSize;
+  UINTN                       VolHdrLen;
+  EFI_FIRMWARE_VOLUME_HEADER  *VolHdr;
+  VARIABLE_STORE_HEADER       *VarStoreHdr;
+
+  Status = SmmStoreLibGetBlockSize (&BlockSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): SmmStoreLibGetBlockSize() failed with: %r\n",
+      __FUNCTION__,
+      Status
+      ));
+    return FALSE;
+  }
+
+  if (Fv.Length % BlockSize != 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): firmware Volume size is not a multiple of 64KiB\n",
+      __FUNCTION__
+      ));
+    return FALSE;
+  }
+
+  SetMem (Fv.Start, Fv.Length, 0xff);
+
+  VolHdrLen = sizeof (*VolHdr) + sizeof (EFI_FV_BLOCK_MAP_ENTRY);
+
+  VolHdr = (EFI_FIRMWARE_VOLUME_HEADER *) Fv.Start;
+  SetMem (VolHdr, sizeof (*VolHdr), 0x00);
+
+  VolHdr->FileSystemGuid = gEfiSystemNvDataFvGuid;
+  VolHdr->FvLength       = Fv.Length;
+  VolHdr->Signature      = EFI_FVH_SIGNATURE;
+  VolHdr->Attributes     = EFI_FVB2_READ_ENABLED_CAP
+                         | EFI_FVB2_READ_STATUS
+                         | EFI_FVB2_WRITE_ENABLED_CAP
+                         | EFI_FVB2_WRITE_STATUS
+                         | EFI_FVB2_STICKY_WRITE
+                         | EFI_FVB2_MEMORY_MAPPED
+                         | EFI_FVB2_ERASE_POLARITY;
+  VolHdr->HeaderLength   = VolHdrLen;
+  VolHdr->Revision       = EFI_FVH_REVISION;
+
+  VolHdr->BlockMap[0].NumBlocks = Fv.Length / BlockSize;
+  VolHdr->BlockMap[0].Length    = BlockSize;
+  VolHdr->BlockMap[1].NumBlocks = 0;
+  VolHdr->BlockMap[1].Length    = 0;
+
+  VolHdr->Checksum = ~CalcChecksum ((CONST UINT16 *) VolHdr, VolHdrLen) + 1;
+
+  VarStoreHdr = (VARIABLE_STORE_HEADER *) (Fv.Start + VolHdrLen);
+  SetMem (VarStoreHdr, sizeof (*VarStoreHdr), 0x00);
+
+  // Authentication-related fields will be filled with 0xff.
+  VarStoreHdr->Signature = gEfiAuthenticatedVariableGuid;
+  // Actual size of the storage is block size, the rest is
+  // Fault Tolerant Write (FTW) space and the FTW spare space.
+  VarStoreHdr->Size      = BlockSize - VolHdrLen;
+  VarStoreHdr->Format    = VARIABLE_STORE_FORMATTED;
+  VarStoreHdr->State     = VARIABLE_STORE_HEALTHY;
+
+  return TRUE;
+}
+
+BOOLEAN
+EFIAPI
+EfiVarsInit (
+  IN OUT MemRange  Fv,
+  OUT EfiVars      *Storage
+  )
+{
+  CONST EFI_FIRMWARE_VOLUME_HEADER  *VolHdr;
+  CONST VARIABLE_STORE_HEADER       *VarStoreHdr;
+  UINT8                             *VolData;
+  UINTN                             VolDataSize;
+
+  if (!InitFv (Fv)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to create variable store",
+      __FUNCTION__
+      ));
+    return FALSE;
+  }
+
+  VolHdr      = (CONST EFI_FIRMWARE_VOLUME_HEADER *) Fv.Start;
+  VolData     = Fv.Start + VolHdr->HeaderLength;
+  VolDataSize = Fv.Length - VolHdr->HeaderLength;
+  VarStoreHdr = (CONST VARIABLE_STORE_HEADER *) VolData;
+
+  Storage->Fv           = Fv;
+  Storage->Store.Start  = VolData + sizeof (*VarStoreHdr);
+  Storage->Store.Length = VolDataSize - sizeof (*VarStoreHdr);
+  Storage->Vars         = NULL;
+
+  return TRUE;
+}
+
+STATIC
+VOID
+StoreVar (
+  IN  CONST EfiVar  *Var,
+  OUT UINT8         *Data
+  )
+{
+  AUTHENTICATED_VARIABLE_HEADER hdr;
+  SetMem (&hdr, sizeof (hdr), 0xff);
+
+  hdr.StartId    = VARIABLE_DATA;
+  hdr.State      = VAR_ADDED;
+  hdr.Reserved   = 0;
+  hdr.Attributes = Var->Attrs;
+  hdr.VendorGuid = Var->Guid;
+  hdr.NameSize   = Var->NameSize;
+  hdr.DataSize   = Var->DataSize;
+
+  CopyMem (Data, &hdr, sizeof (hdr));
+  Data += sizeof (hdr);
+
+  CopyMem (Data, Var->Name, Var->NameSize);
+  CopyMem (Data + Var->NameSize, Var->Data, Var->DataSize);
+}
+
+BOOLEAN
+EFIAPI
+EfiVarsWrite (
+  IN EfiVars  *Storage
+  )
+{
+  MemRange  VarStore;
+  UINT8     *OutData;
+  EfiVar    *Var;
+  UINTN     VarSize;
+
+  VarStore = Storage->Store;
+  OutData  = VarStore.Start;
+
+  for (Var = Storage->Vars; Var != NULL; Var = Var->Next) {
+    VarSize =
+      sizeof (AUTHENTICATED_VARIABLE_HEADER) + Var->NameSize + Var->DataSize;
+    if (OutData + VarSize > VarStore.Start + VarStore.Length) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a(): not enough space to serialize Variable Store (have 0x%x).\n",
+        __FUNCTION__,
+        VarStore.Length
+        ));
+      return FALSE;
+    }
+
+    StoreVar (Var, OutData);
+    OutData += HEADER_ALIGN (VarSize);
+  }
+
+  // The rest is "uninitialized".
+  SetMem (OutData, VarStore.Length - (OutData - VarStore.Start), 0xff);
+
+  return TRUE;
+}
+
+EfiVar *
+EFIAPI
+EfiVarsCreateVar (
+  IN EfiVars  *Storage
+  )
+{
+  EfiVar *NewVar;
+  EfiVar *Var;
+
+  NewVar = AllocateZeroPool (sizeof (*NewVar));
+  if (NewVar == NULL)
+    return NULL;
+
+  Var = Storage->Vars;
+  if (Var == NULL) {
+    Storage->Vars = NewVar;
+  } else {
+    while (Var->Next != NULL)
+      Var = Var->Next;
+    Var->Next = NewVar;
+  }
+
+  return NewVar;
+}
+
+VOID
+EFIAPI
+EfiVarsFree (
+  IN EfiVars  *Storage
+  )
+{
+  EfiVar *Next;
+  EfiVar *Var;
+
+  for (Var = Storage->Vars; Var != NULL; Var = Next) {
+    Next = Var->Next;
+
+    FreePool (Var->Name);
+    FreePool (Var->Data);
+    FreePool (Var);
+  }
+}

--- a/DasharoPayloadPkg/Library/EfiVarsLib/EfiVarsLib.inf
+++ b/DasharoPayloadPkg/Library/EfiVarsLib/EfiVarsLib.inf
@@ -1,0 +1,41 @@
+## @file
+#  Simple EFI variables driver as a library.
+#
+#  The functionality is limited to store initialization and addition of
+#  variables.
+#
+#  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = EfiVarsLib
+  FILE_GUID                      = 48B9E949-AA19-4193-A216-878772E61A25
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = EfiVarsLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  EfiVarsLib.c
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  SmmStoreLib
+
+[Guids]
+  gEfiAuthenticatedVariableGuid
+  gEfiSystemNvDataFvGuid

--- a/DasharoPayloadPkg/Library/FmapLib/FmapLib.c
+++ b/DasharoPayloadPkg/Library/FmapLib/FmapLib.c
@@ -1,0 +1,197 @@
+/** @file
+  coreboot flash map data parsing library.
+
+Copyright (c) 2024, coreboot project<BR>
+SPDX-License-Identifier: BSD-3-Clause or GPL-2.0-only
+
+**/
+
+#include <Library/FmapLib.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+/* No-op on x86, but still useful to have. */
+#define le32toh(x) (x)
+#define le16toh(x) (x)
+
+STATIC
+BOOLEAN
+IsPrint (
+  IN CHAR8  Chr
+  )
+{
+  return (Chr > 32 && Chr < 126);
+}
+
+/* Make a best-effort assessment if the given fmap is real */
+STATIC
+UINTN
+IsValidFmap (
+  IN CONST Fmap *Map
+  )
+{
+  UINTN Idx;
+
+  if (CompareMem (Map, FMAP_SIGNATURE, AsciiStrLen (FMAP_SIGNATURE)) != 0)
+    return 0;
+  /* strings containing the magic tend to fail here */
+  if (Map->ver_major != FMAP_VER_MAJOR)
+    return 0;
+  /* a basic consistency check: flash should be larger than fmap */
+  if (le32toh (Map->size) <
+    sizeof (*Map) + le16toh (Map->nareas) * sizeof (FmapArea))
+    return 0;
+
+  /* fmap-alikes along binary data tend to fail on having a valid,
+   * null-terminated string in the name field.*/
+  Idx = 0;
+  while (Idx < FMAP_STRLEN) {
+    if (Map->name[Idx] == 0)
+      break;
+    if (!IsPrint (Map->name[Idx]))
+      return 0;
+    if (Idx == FMAP_STRLEN - 1) {
+      /* name is specified to be null terminated single-word string
+       * without spaces. We did not break in the 0 test, we know it
+       * is a printable spaceless string but we're seeing FMAP_STRLEN
+       * symbols, which is one too many.
+       */
+      return 0;
+    }
+    Idx++;
+  }
+  return 1;
+
+}
+
+/* returns size of fmap data structure if successful, <0 to indicate error */
+INTN
+EFIAPI
+FmapSize (
+  IN CONST Fmap *Map
+  )
+{
+  if (!Map)
+    return -1;
+
+  return sizeof (*Map) + (le16toh (Map->nareas) * sizeof (FmapArea));
+}
+
+/* brute force linear search */
+STATIC
+INTN
+FmapLsearch (
+  IN CONST UINT8 *Image,
+  IN UINTN Len
+  )
+{
+  INTN Offset;
+  BOOLEAN FmapFound;
+
+  FmapFound = FALSE;
+
+  for (Offset = 0; Offset < Len - sizeof (Fmap); Offset++) {
+    if (IsValidFmap ((CONST Fmap *) &Image[Offset])) {
+      FmapFound = 1;
+      break;
+    }
+  }
+
+  if (!FmapFound)
+    return -1;
+
+  if (Offset + FmapSize ((CONST Fmap *) &Image[Offset]) > Len)
+    return -1;
+
+  return Offset;
+}
+
+/* if Image length is a power of 2, use binary search */
+STATIC
+INTN
+FmapBsearch (
+  IN CONST UINT8 *Image,
+  IN UINTN Len
+  )
+{
+  INTN Offset;
+  UINTN Stride;
+  BOOLEAN FmapFound;
+
+  FmapFound = FALSE;
+
+  /*
+   * For efficient operation, we start with the largest Stride possible
+   * and then decrease the Stride on each iteration. Also, check for a
+   * remainder when modding the Offset with the previous Stride. This
+   * makes it so that each Offset is only checked once.
+   */
+  for (Stride = Len / 2; Stride >= 16; Stride /= 2) {
+    if (FmapFound)
+      break;
+
+    for (Offset = 0; Offset < Len - sizeof (Fmap); Offset += Stride) {
+      if ((Offset % (Stride * 2) == 0) && (Offset != 0))
+          continue;
+      if (IsValidFmap ((CONST Fmap *) &Image[Offset])) {
+        FmapFound = 1;
+        break;
+      }
+    }
+  }
+
+  if (!FmapFound)
+    return -1;
+
+  if (Offset + FmapSize ((CONST Fmap *) &Image[Offset]) > Len)
+    return -1;
+
+  return Offset;
+}
+
+STATIC
+BOOLEAN
+IsPowerOf2 (
+  UINTN Number
+)
+{
+  return Number != 0 && (Number & (Number - 1)) == 0;
+}
+
+INTN
+EFIAPI
+FmapFind (
+  CONST UINT8 *Image,
+  UINTN Len
+  )
+{
+  if ((Image == NULL) || (Len == 0))
+    return -1;
+
+  if (IsPowerOf2 (Len))
+    return FmapBsearch (Image, Len);
+
+  return FmapLsearch (Image, Len);
+}
+
+CONST FmapArea *
+EFIAPI
+FmapFindArea (
+  IN CONST Fmap *Map,
+  IN CONST CHAR8 *Name
+)
+{
+  UINTN Idx;
+
+  if (!Map || !Name)
+    return NULL;
+
+  for (Idx = 0; Idx < le16toh (Map->nareas); Idx++) {
+    if (AsciiStrCmp ((CONST CHAR8 *) Map->areas[Idx].name, Name) == 0) {
+      return &Map->areas[Idx];
+    }
+  }
+
+  return NULL;
+}

--- a/DasharoPayloadPkg/Library/FmapLib/FmapLib.inf
+++ b/DasharoPayloadPkg/Library/FmapLib/FmapLib.inf
@@ -1,0 +1,32 @@
+## @file
+#  coreboot flash map data parsing library.
+#
+#  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FmapLib
+  FILE_GUID                      = 757DD2FD-A779-4F4C-BE43-A584649F838A
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FmapLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  FmapLib.c
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -80,3 +80,48 @@ ReadCurrentFirmware (
 
   return Image;
 }
+
+/**
+  Migrates data from current firmware to new image before it's written.
+
+  @param[in] Current  Current image used as a source of data.
+  @param[in] New      New image which gets patched.
+
+  @return NULL  On error.
+**/
+VOID *
+EFIAPI
+MergeFirmwareImages (
+  IN CONST VOID  *Current,
+  IN CONST VOID  *New
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       *Merged;
+  UINTN       FwSize;
+
+  Status = FmpDeviceGetSize (&FwSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): FmpDeviceGetSize() failed with: %r\n",
+      __FUNCTION__,
+      Status
+      ));
+    return NULL;
+  }
+
+  Merged = AllocateCopyPool (FwSize, New);
+  if (Merged == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to allocate merged image buffer\n",
+      __FUNCTION__
+      ));
+    return NULL;
+  }
+
+  // TODO: perform data migration here.
+
+  return Merged;
+}

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -1,9 +1,71 @@
 #include "Flashing.h"
 
+#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
+#include <Library/FmapLib.h>
 #include <Library/FmpDeviceLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/SmmStoreLib.h>
+
+typedef enum {
+  REGION_MIGRATED,
+  REGION_NOT_IN_SRC,
+  REGION_NOT_IN_DST,
+  REGION_OF_DIFFERENT_SIZE,
+} RegionMigrationStatus;
+
+typedef struct {
+  CONST UINT8  *Current;
+  UINT8        *Updated;
+  CONST Fmap   *CurrentFmap;
+  CONST Fmap   *UpdatedFmap;
+  UINTN        FwSize;
+} MigrationData;
+
+STATIC
+BOOLEAN
+GetFmap (
+  IN  CONST UINT8  *Image,
+  IN  UINTN        Size,
+  OUT CONST Fmap   **Map
+  )
+{
+  INTN            FmapOffset;
+  CONST FmapArea  *FmapRegion;
+
+  FmapOffset = FmapFind (Image, Size);
+  if (FmapOffset < 0) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to find FMAP\n", __FUNCTION__));
+    *Map = NULL;
+    return FALSE;
+  }
+
+  *Map = (CONST Fmap *) (Image + FmapOffset);
+
+  if ((*Map)->size > Size) {
+    DEBUG ((DEBUG_ERROR, "%a(): FMAP is larger than firmware\n", __FUNCTION__));
+    return FALSE;
+  }
+
+  FmapRegion = FmapFindArea (*Map, "FMAP");
+  if (FmapRegion == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a(): FMAP doesn't describe itself\n", __FUNCTION__));
+    return FALSE;
+  }
+
+  if (FmapRegion->offset != FmapOffset) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): wrong FMAP offset (expected: 0x%x, actual: 0x%x)\n",
+      __FUNCTION__,
+      FmapRegion->offset,
+      FmapOffset
+      ));
+    return FALSE;
+  }
+
+  return TRUE;
+}
 
 /**
   Read current firmware in full and return as newly allocated pool memory.
@@ -82,6 +144,82 @@ ReadCurrentFirmware (
 }
 
 /**
+  Migrates a flash map region from current firmware to a new one.
+
+  @param[in] RegionName  Name of the region to migrate.
+  @param[in] Data        New image which gets patched.
+
+  @return RegionMigrationStatus  Status which might not be considered an error
+                                 depending on the region.
+**/
+STATIC
+RegionMigrationStatus
+MigrateRegion (
+  IN CONST CHAR8          *RegionName,
+  IN CONST MigrationData  *Data
+  )
+{
+  CONST FmapArea  *CurrentRegion;
+  CONST FmapArea  *UpdatedRegion;
+
+  CurrentRegion = FmapFindArea (Data->CurrentFmap, RegionName);
+  if (CurrentRegion == NULL) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a(): failed to find %a region in current firmware\n",
+      __FUNCTION__,
+      RegionName
+      ));
+    return REGION_NOT_IN_SRC;
+  }
+
+  UpdatedRegion = FmapFindArea (Data->UpdatedFmap, RegionName);
+  if (UpdatedRegion == NULL) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a(): failed to find %a region in new firmware\n",
+      __FUNCTION__,
+      RegionName
+      ));
+    return REGION_NOT_IN_DST;
+  }
+
+  if (CurrentRegion->size != UpdatedRegion->size) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a(): %a regions don't match in size (current: 0x%x, updated: 0x%x)\n",
+      __FUNCTION__,
+      RegionName,
+      CurrentRegion->size,
+      UpdatedRegion->size
+      ));
+    return REGION_OF_DIFFERENT_SIZE;
+  }
+
+  CopyMem (
+    Data->Updated + UpdatedRegion->offset,
+    Data->Current + CurrentRegion->offset,
+    UpdatedRegion->size
+    );
+
+  return REGION_MIGRATED;
+}
+
+STATIC
+BOOLEAN
+MigrateVariables (
+  IN CONST MigrationData  *Data
+  )
+{
+  RegionMigrationStatus  Status;
+
+  Status = MigrateRegion ("SMMSTORE", Data);
+
+  return Status == REGION_MIGRATED
+      || Status == REGION_NOT_IN_DST;
+}
+
+/**
   Migrates data from current firmware to new image before it's written.
 
   @param[in] Current  Current image used as a source of data.
@@ -96,11 +234,18 @@ MergeFirmwareImages (
   IN CONST VOID  *New
   )
 {
-  EFI_STATUS  Status;
-  UINT8       *Merged;
-  UINTN       FwSize;
+  EFI_STATUS     Status;
+  MigrationData  Data;
 
-  Status = FmpDeviceGetSize (&FwSize);
+  Data.Current = Current;
+
+  //
+  // The assumption is that current firmware image contains all the interesting
+  // data, i.e. if there was anything that needed to be flushed, it was flushed
+  // before the snapshot was taken.
+  //
+
+  Status = FmpDeviceGetSize (&Data.FwSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
@@ -111,8 +256,8 @@ MergeFirmwareImages (
     return NULL;
   }
 
-  Merged = AllocateCopyPool (FwSize, New);
-  if (Merged == NULL) {
+  Data.Updated = AllocateCopyPool (Data.FwSize, New);
+  if (Data.Updated == NULL) {
     DEBUG ((
       DEBUG_ERROR,
       "%a(): failed to allocate merged image buffer\n",
@@ -121,7 +266,39 @@ MergeFirmwareImages (
     return NULL;
   }
 
-  // TODO: perform data migration here.
+  if (!GetFmap (Data.Current, Data.FwSize, &Data.CurrentFmap)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to parse current firmware\n",
+      __FUNCTION__
+      ));
+    goto Fail;
+  }
 
-  return Merged;
+  if (!GetFmap (Data.Updated, Data.FwSize, &Data.UpdatedFmap)) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a(): failed to parse updated firmware\n",
+      __FUNCTION__
+      ));
+    if (Data.UpdatedFmap == NULL) {
+      //
+      // Not a hard error.  It's conceivable that for a capsule to be used to
+      // flash non-coreboot firmware.
+      //
+      return Data.Updated;
+    }
+    goto Fail;
+  }
+
+  if (!MigrateVariables (&Data)) {
+    DEBUG ((DEBUG_ERROR, "%a(): MigrateVariables() failed\n", __FUNCTION__));
+    goto Fail;
+  }
+
+  return Data.Updated;
+
+Fail:
+  FreePool (Data.Updated);
+  return NULL;
 }

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -1,0 +1,82 @@
+#include "Flashing.h"
+
+#include <Library/DebugLib.h>
+#include <Library/FmpDeviceLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/SmmStoreLib.h>
+
+/**
+  Read current firmware in full and return as newly allocated pool memory.
+
+  @return NULL  On error.
+**/
+VOID *
+EFIAPI
+ReadCurrentFirmware (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       *Image;
+  UINTN       FwSize;
+  UINTN       Block;
+  UINTN       BlockSize;
+  UINTN       NumBytes;
+
+  Status = SmmStoreLibGetBlockSize (&BlockSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): SmmStoreLibGetBlockSize() failed with: %r\n",
+      __FUNCTION__,
+      Status
+      ));
+    return NULL;
+  }
+
+  Status = FmpDeviceGetSize (&FwSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): FmpDeviceGetSize() failed with: %r\n",
+      __FUNCTION__,
+      Status
+      ));
+    return NULL;
+  }
+
+  Image = AllocatePool (FwSize);
+  if (Image == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to allocate current image buffer\n",
+      __FUNCTION__
+      ));
+    return NULL;
+  }
+
+  for (Block = 0; Block < FwSize / BlockSize; Block++) {
+    NumBytes = BlockSize;
+    Status = SmmStoreLibReadAnyBlock (
+               Block,
+               0,
+               &NumBytes,
+               Image + Block * BlockSize
+               );
+    if (EFI_ERROR (Status) || NumBytes != BlockSize) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a(): read %d out of %d bytes of flash at 0x%x (%r)\n",
+        __FUNCTION__,
+        NumBytes,
+        BlockSize,
+        Block * BlockSize,
+        Status
+        ));
+      FreePool (Image);
+      return NULL;
+    }
+  }
+
+  return Image;
+}

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -249,6 +249,21 @@ MigrateRomhole (
       || Status == REGION_NOT_IN_DST;
 }
 
+STATIC
+BOOLEAN
+MigrateBootLogo (
+  IN CONST MigrationData  *Data
+  )
+{
+  RegionMigrationStatus  Status;
+
+  Status = MigrateRegion ("BOOTSPLASH", Data, FALSE);
+
+  return Status == REGION_MIGRATED
+      || Status == REGION_NOT_IN_SRC
+      || Status == REGION_NOT_IN_DST;
+}
+
 /**
   Migrates data from current firmware to new image before it's written.
 
@@ -328,6 +343,11 @@ MergeFirmwareImages (
 
   if (!MigrateRomhole (&Data)) {
     DEBUG ((DEBUG_ERROR, "%a(): MigrateRomhole () failed\n", __FUNCTION__));
+    goto Fail;
+  }
+
+  if (!MigrateBootLogo (&Data)) {
+    DEBUG ((DEBUG_ERROR, "%a(): MigrateBootLogo () failed\n", __FUNCTION__));
     goto Fail;
   }
 

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.h
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.h
@@ -12,4 +12,19 @@ ReadCurrentFirmware (
   VOID
   );
 
+/**
+  Migrates data from current firmware to new image before it's written.
+
+  @param[in] Current  Current image used as a source of data.
+  @param[in] New      New image which gets patched.
+
+  @return NULL  On error.
+**/
+VOID *
+EFIAPI
+MergeFirmwareImages (
+  IN CONST VOID  *Current,
+  IN CONST VOID  *New
+  );
+
 #endif // FLASHING_H__

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.h
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.h
@@ -1,0 +1,15 @@
+#ifndef FLASHING_H__
+#define FLASHING_H__
+
+/**
+  Read current firmware in full and return as newly allocated pool memory.
+
+  @return NULL  On error.
+**/
+VOID *
+EFIAPI
+ReadCurrentFirmware (
+  VOID
+  );
+
+#endif // FLASHING_H__

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -32,6 +32,7 @@
 [LibraryClasses]
   BaseMemoryLib
   BlParseLib
+  CbfsLib
   DebugLib
   FmapLib
   MemoryAllocationLib

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -34,6 +34,7 @@
   BlParseLib
   CbfsLib
   DebugLib
+  EfiVarsLib
   FmapLib
   MemoryAllocationLib
   PrintLib

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   BlParseLib
   DebugLib
+  FmapLib
   MemoryAllocationLib
   PrintLib
   SmmStoreLib

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -26,6 +26,7 @@
 #
 
 [Sources]
+  Flashing.c
   FmpDeviceSmmLib.c
 
 [LibraryClasses]

--- a/MdeModulePkg/Logo/Logo.c
+++ b/MdeModulePkg/Logo/Logo.c
@@ -95,20 +95,19 @@ GetImage (
             (UINTN*) &(Image->Height),
             (UINTN*) &(Image->Width));
 
-    if (EFI_ERROR (Status)) {
+    if (!EFI_ERROR (Status)) {
+      Image->Bitmap = Blt;
       return Status;
     }
 
-    Image->Bitmap = Blt;
-
-    return Status;
-  } else {
-    // No logo in CBMEM, fallback to builtin
-    *Attribute = mLogos[Current].Attribute;
-    *OffsetX   = mLogos[Current].OffsetX;
-    *OffsetY   = mLogos[Current].OffsetY;
-    return mHiiImageEx->GetImageEx (mHiiImageEx, mHiiHandle, mLogos[Current].ImageId, Image);
+    DEBUG ((DEBUG_ERROR, "Failed to translate logo image: %r\n", Status));
   }
+
+  // No or bad logo in CBMEM, fallback to builtin
+  *Attribute = mLogos[Current].Attribute;
+  *OffsetX   = mLogos[Current].OffsetX;
+  *OffsetY   = mLogos[Current].OffsetY;
+  return mHiiImageEx->GetImageEx (mHiiImageEx, mHiiHandle, mLogos[Current].ImageId, Image);
 }
 
 EDKII_PLATFORM_LOGO_PROTOCOL  mPlatformLogo = {


### PR DESCRIPTION
Issue: https://github.com/Dasharo/dasharo-issues/issues/809

Lots of code changes, but most of that is imported code:
 - FMAP from coreboot (updated to be more EDK-like)
 - CBFS from `cbfstool` in coreboot (essentially unchanged)
 - SMMSTORE code from `smmstoretool` in coreboot (reduced to bare minimum)
 - code for iterating EFI variables is from `DasharoVariablesLib` (adjusted to fit the use case)

The main code is in `FmpDeviceSmmLib` in a new file `Flashing.c`.