### PR TITLE
DasharoPayloadPkg: Use INIT-SIPI-SIPI for first AP wakeup

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -540,6 +540,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciSerialParameters|$(PCI_SERIAL_PARAMETERS)
 
   gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber|$(MAX_LOGICAL_PROCESSORS)
+  gUefiCpuPkgTokenSpaceGuid.PcdFirstTimeWakeUpAPsBySipi|FALSE
 
 !if $(PS2_KEYBOARD_ENABLE) == TRUE
   gDasharoPayloadPkgTokenSpaceGuid.PcdSkipPs2Detect|FALSE


### PR DESCRIPTION
It has been observed on MinnowBoard Turbot that the detected CPU count is lower than the number of all cores. In the tested unit, CPU is dual core, so only the BSP is detected. However, similar situation is observed on MTL laptop, where a total of 22 cores should be reported, but only 1 is detected.

After EDK2 rebase a new PCD has been added, PcdFirstTimeWakeUpAPsBySipi which, when enabled (by default), sends only SIPI to APs. When disabled sends full INIT-SIPI-SIPI sequence. Only the latter case causes all the APs to wake up and be detected.