### PR TITLE
to be squashed with "fix PEI memory range discovery code"

### DIFF
--- a/DasharoPayloadPkg/BlSupportPei/BlSupportPei.h
+++ b/DasharoPayloadPkg/BlSupportPei/BlSupportPei.h
@@ -37,9 +37,4 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Ppi/MasterBootMode.h>
 #include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>
 
-typedef struct {
-  UINT32  UsableLowMemTop;
-  UINT32  SystemLowMemTop;
-} PAYLOAD_MEM_INFO;
-
 #endif


### PR DESCRIPTION
In some cases, it isn't possible to differentiate between structures in RAM (e.g. coreboot tables) and memory reserved by System Agent (e.g. TSEG, GSM) based on memory region type. Both are reported as reserved memory and they may even be combined into one region, but their caching methods must be different. Because of that, MTRR setting code is no longer called at this point. This depends on coreboot setting memory caching attributes properly, which it already does.