### PR TITLE
Bring back TPM PPI in RAM

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -326,7 +326,8 @@
 !if $(TPM_ENABLE) == TRUE
   Tpm12CommandLib|SecurityPkg/Library/Tpm12CommandLib/Tpm12CommandLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
-  Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+  Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
+  Tcg2PhysicalPresencePlatformLib|DasharoPayloadPkg/Library/Tcg2PhysicalPresencePlatformLibUefipayload/DxeTcg2PhysicalPresencePlatformLib.inf
   Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
 !else

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -111,6 +111,7 @@
   DEFINE APU_CONFIG_ENABLE              = FALSE
   DEFINE USE_PLATFORM_GOP               = FALSE
   DEFINE USE_LAPTOP_LID_LIB             = FALSE
+  DEFINE USE_UEFIVAR_BACKED_TPM_PPI     = FALSE
 
   #
   # Network definition
@@ -326,8 +327,13 @@
 !if $(TPM_ENABLE) == TRUE
   Tpm12CommandLib|SecurityPkg/Library/Tpm12CommandLib/Tpm12CommandLib.inf
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+
+!if $(USE_UEFIVAR_BACKED_TPM_PPI) == TRUE
+  Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+!else
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
   Tcg2PhysicalPresencePlatformLib|DasharoPayloadPkg/Library/Tcg2PhysicalPresencePlatformLibUefipayload/DxeTcg2PhysicalPresencePlatformLib.inf
+!endif
   Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
 !else

--- a/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
+++ b/OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.c
@@ -138,6 +138,7 @@ QemuTpmInitPPI (
     mPpi->NextStep    = TCG2_PHYSICAL_PRESENCE_NO_ACTION;
   }
 
+  WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
   return EFI_SUCCESS;
 
 InvalidPpiAddress:
@@ -804,12 +805,13 @@ Tcg2ExecutePendingTpmRequest (
       if (mPpi->Request != TCG2_PHYSICAL_PRESENCE_NO_ACTION) {
         break;
       }
-
+      WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
       return;
   }
 
   Print (L"Rebooting system to make TPM2 settings in effect\n");
   WriteBackDataCacheRange((VOID*)mPpi, sizeof(QEMU_TPM_PPI));
+  gBS->Stall(500000);
   gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
   ASSERT (FALSE);
 }


### PR DESCRIPTION
Added more flushes and a stall before reset to get the flush or wbinvd hit the RAM.

Now with the VP66xx power cycles fixed: https://github.com/Dasharo/dasharo-blobs/pull/31 RAM backed for PPI works on VP6670 (the power cycle fix was not enough, the flushes in this PR are required as well). Similar fixes landed for VP32xx and VP2430 and the TPM PPI in RAM works there too.

Tested also on VP2410, where RAM backed did not want to work too. Unfortunately still doesn't work, even when request is sent from OS. The memory content of TPM PPI area looks random.