### PR TITLE
DasharoSystemFeaturesUiLib: Use callbacks to update CPU Throttling Threshold

### DIFF
--- a/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -192,7 +192,6 @@ DasharoSystemFeaturesUiLibConstructor (
   PRIVATE_DATA(ShowPs2Option) = FixedPcdGetBool (PcdShowPs2Option);
   PRIVATE_DATA(Have2ndUart) = FixedPcdGetBool (PcdHave2ndUart);
   PRIVATE_DATA(ShowCpuThrottlingThreshold) = FixedPcdGetBool (PcdShowCpuThrottlingThreshold);
-  PRIVATE_DATA(CpuMaxTemperature) = FixedPcdGet8 (PcdCpuMaxTemperature);
   PRIVATE_DATA(ShowCpuCoreDisable) = FixedPcdGetBool(PcdShowCpuCoreDisable);
   PRIVATE_DATA(ShowCpuHyperThreading) = FixedPcdGetBool(PcdShowCpuHyperThreading);
   PRIVATE_DATA(WatchdogAvailable) = FixedPcdGetBool (PcdShowOcWdtOptions);
@@ -280,7 +279,7 @@ DasharoSystemFeaturesUiLibConstructor (
 #undef LOAD_VAR
 
   PRIVATE_DATA(CpuThrottlingThreshold) =
-    PRIVATE_DATA(CpuMaxTemperature) - PRIVATE_DATA(CpuThrottlingOffset);
+    FixedPcdGet8(PcdCpuMaxTemperature) - PRIVATE_DATA(CpuThrottlingOffset);
 
   if (PRIVATE_DATA(HybridCpuArchitecture) &&
       PRIVATE_DATA(SmallCoreActiveCount) == 0 &&
@@ -619,10 +618,29 @@ DasharoSystemFeaturesCallback (
 {
   EFI_STATUS                                 Status;
   EFI_INPUT_KEY                              Key;
+  DASHARO_SYSTEM_FEATURES_PRIVATE_DATA       *Private;
 
   Status = EFI_SUCCESS;
+  Private = DASHARO_SYSTEM_FEATURES_PRIVATE_DATA_FROM_THIS (This);
 
   switch (Action) {
+  case EFI_BROWSER_ACTION_RETRIEVE:
+    switch (QuestionId) {
+    case CPU_THROTTLING_THRESHOLD_QUESTION_ID:
+      /*
+       * For some reason CpuMaxTemperature is zeroed when user changes CPU
+       * throttling, exits PWR MGMT menu, goes to front page and goes back to
+       * PWR MGMT menu again. It results in the negative throttling threshold
+       * to be displayed. Always calculate the threshold based on PCD and
+       * current throttling offset value.
+       */
+      Value->u8 = FixedPcdGet8(PcdCpuMaxTemperature) - Private->DasharoFeaturesData.CpuThrottlingOffset;
+      break;
+    default:
+      Status = EFI_UNSUPPORTED;
+      break;
+    }
+    break;
   case EFI_BROWSER_ACTION_DEFAULT_STANDARD:
   case EFI_BROWSER_ACTION_DEFAULT_MANUFACTURING:
     {

--- a/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -85,7 +85,6 @@ typedef struct {
   BOOLEAN                  SerialPort2Redirection;
   UINT8                    CpuThrottlingThreshold;
   UINT8                    CpuThrottlingOffset;
-  UINT8                    CpuMaxTemperature;
   BOOLEAN                  HybridCpuArchitecture;
   BOOLEAN                  HyperThreadingSupported;
   BOOLEAN                  HyperThreading;
@@ -152,5 +151,6 @@ typedef struct {
 #define SERIAL_PORT2_REDIR_QUESTION_ID       0x800B
 #define HYPER_THREADING_QUESTION_ID          0x800C
 #define CPU_THROTTLING_OFFSET_QUESTION_ID    0x800D
+#define CPU_THROTTLING_THRESHOLD_QUESTION_ID 0x800E
 
 #endif

--- a/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/DasharoModulePkg/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -369,19 +369,18 @@ formset
               maximum = 63,
               step    = 1,
 
-              write   set(FeaturesData.CpuThrottlingThreshold, get(FeaturesData.CpuMaxTemperature) - pushthis);
+              write   set(FeaturesData.CpuThrottlingThreshold, FixedPcdGet8(PcdCpuMaxTemperature) - pushthis);
 
       endnumeric;
 
       grayoutif TRUE;
         numeric varid   = FeaturesData.CpuThrottlingThreshold,
+                questionid = CPU_THROTTLING_THRESHOLD_QUESTION_ID,
                 prompt  = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_PROMPT),
                 help    = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_HELP),
+                flags   = INTERACTIVE,
                 minimum = 0,
                 maximum = 255,
-
-                read   get(FeaturesData.CpuMaxTemperature) - get(FeaturesData.CpuThrottlingOffset);
-
         endnumeric;
       endif;
     endif;


### PR DESCRIPTION
For some reason the CPU Throttling Threshold dsiplayed negative value when user changed CPU throttling, exited Power Management Options menu, went back to front page and then entered Power Management Options menu again.

Always calculate the threshold based on PCD and current throttling offset value. Add interactive flag to the options and patch the value in the callback.