### PR TITLE
DasharoPayloadPkg.fdf: increase PEI FV size by 192 KiB

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.fdf
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.fdf
@@ -11,15 +11,15 @@
 ################################################################################
 [FD.UefiPayload]
 BaseAddress   = 0x800000|gDasharoPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase
-Size          = 0xE00000|gDasharoPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
+Size          = 0xE30000|gDasharoPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
 ErasePolarity = 1
 BlockSize     = 0x1000
-NumBlocks     = 0xE00
+NumBlocks     = 0xE30
 
-0x00000000|0x060000
+0x00000000|0x090000
 FV = PEIFV
 
-0x00060000|0xDA0000
+0x00090000|0xDA0000
 FV = DXEFV
 
 ################################################################################


### PR DESCRIPTION
https://github.com/coreboot/coreboot/commit/9c15a9b7ae2e adds `-z common-page-size=0x1000` to linker's invocation to get proper alignment, which results in increasing final image size.

Part of rebasing Dasharo/coreboot onto upstream 24.12 (https://github.com/Dasharo/dasharo-issues/issues/1241).