### PR TITLE
Fum warning

### DIFF
--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -437,7 +437,7 @@ MigrateBootLogo (
 
 STATIC
 BOOLEAN
-MigrageGbeRegion (
+MigrateGbeRegion (
   IN CONST MigrationData  *Data
   )
 {

--- a/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1190,6 +1190,11 @@ WarnIfFirmwareUpdateMode (
       );
   ASSERT_EFI_ERROR (Status);
 
+  // Don't bother checking user presence if FUM was triggered by capsule update
+  if (GetBootModeHob() == BOOT_ON_FLASH_UPDATE) {
+    return TRUE;
+  }
+
   Status = gRT->GetTime (&Time, NULL);
   //
   // Don't check status, even if the call failed we still have "random" data


### PR DESCRIPTION
Do not show the FUM key prompt if FUM was triggered by capsule update. This brings the capsule update flow in line with proprietary implementations and unblocks automated testing of capsules, without a serial console.