### PR TITLE
MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c: Add BSD based systems

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2542,6 +2542,9 @@ STATIC CONST PRE_INSTALLED_BOOT_OPT PreInstalledBootOpts[] = {
   { L"\\EFI\\Microsoft\\Boot\\bootmgfw.efi", L"Windows Boot Manager (on %s)" },
   { L"\\EFI\\Suse\\elilo.efi",               L"Suse Boot Manager (on %s)" },
   { L"\\EFI\\Redhat\\elilo.efi",             L"RedHat Boot Manager (on %s)" },
+  { L"\\EFI\\freebsd\\loader.efi",           L"FreeBSD (on %s)" },
+  { L"\\EFI\\opnsense\\loader.efi",          L"OPNsense (on %s)" },
+  { L"\\EFI\\pfsense\\loader.efi",           L"pfSense (on %s)" },
 };
 
 STATIC CONST PRE_INSTALLED_BOOT_OPT PreInstalledBootOptsShim[] = {


### PR DESCRIPTION
Needed for OSFV to boot systems in standard way.

Note that by deafult all of these systems install under efi/freebsd/loader.efi, so we need to change freebsd to opnsense/pfsense based on what derivative of FreeBSD we are using.

 
![image](https://github.com/user-attachments/assets/03e83a55-b927-4655-b4f5-8bffdfe1c619)
