### PR TITLE
Extend build workflow with build test of DasharoPayloadPkg

### DIFF
--- a/.github/scripts/build-dasharo-payload-pkg.sh
+++ b/.github/scripts/build-dasharo-payload-pkg.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+# edksetup.sh interprets the parameters passed to the script and aborts if it
+# doesn't like them, so abort early if any are passed in to avoid confusion
+if [ $# -ne 0 ]; then
+    echo "The $0 script doesn't accept any parameters"
+    exit 1
+fi
+
+make -C BaseTools
+source ./edksetup.sh
+
+export EDK2_PLATFORMS_PATH="$WORKSPACE/edk2-platforms"
+export PACKAGES_PATH="$WORKSPACE:\
+$WORKSPACE/ipxe/src/bin-x86_64-efi-sb:\
+$EDK2_PLATFORMS_PATH/Platform/Intel:\
+$EDK2_PLATFORMS_PATH/Silicon/Intel:\
+$EDK2_PLATFORMS_PATH/Features/Intel:\
+$EDK2_PLATFORMS_PATH/Features/Intel/Debugging:\
+$EDK2_PLATFORMS_PATH/Features/Intel/Network:\
+$EDK2_PLATFORMS_PATH/Features/Intel/OutOfBandManagement:\
+$EDK2_PLATFORMS_PATH/Features/Intel/PowerManagement:\
+$EDK2_PLATFORMS_PATH/Features/Intel/SystemInformation:\
+$EDK2_PLATFORMS_PATH/Features/Intel/UserInterface:\
+$EDK2_PLATFORMS_PATH/Drivers"
+
+function build_dasharopayloadpkg_64() {
+    build -a IA32 -a X64 -t GCC5 \
+          -D ABOVE_4G_MEMORY=FALSE \
+          -D BOOTLOADER=COREBOOT \
+          -D BOOTSPLASH_IMAGE=TRUE \
+          -D CAPSULE_SUPPORT=TRUE \
+          -D CAPSULE_MAIN_FW_GUID=32a75a2a-17ff-4d1b-88c2-e9dff5db53e7 \
+          -D CPU_TIMER_LIB_ENABLE=FALSE \
+          -D DASHARO_SYSTEM_FEATURES_ENABLE=TRUE \
+          -D DISABLE_SERIAL_TERMINAL=FALSE \
+          -D NETWORK_IPXE=TRUE \
+          -D OPAL_PASSWORD_ENABLE=TRUE \
+          -D PERFORMANCE_MEASUREMENT_ENABLE=TRUE \
+          -D PRIORITIZE_INTERNAL=TRUE \
+          -D PS2_KEYBOARD_ENABLE=TRUE \
+          -D SATA_PASSWORD_ENABLE=TRUE \
+          -D SECURE_BOOT_DEFAULT_ENABLE=FALSE \
+          -D SECURE_BOOT_ENABLE=TRUE \
+          -D SERIAL_TERMINAL=TRUE \
+          -D SETUP_PASSWORD_ENABLE=TRUE \
+          -D SIO_BUS_ENABLE=TRUE \
+          -D UART_ON_SUPERIO=TRUE \
+          -D USE_CBMEM_FOR_CONSOLE=TRUE \
+          -p DasharoPayloadPkg/DasharoPayloadPkg.dsc \
+          "$@"
+}
+
+# According to DasharoPayloadPkg/DasharoPayloadPkg.fdf:
+# SECTION PE32 = DasharoPayloadPkg/NetworkDrivers/ipxe.efi
+mkdir -p ./DasharoPayloadPkg/NetworkDrivers
+cp ./ipxe/src/bin-x86_64-efi-sb/ipxe.efi ./DasharoPayloadPkg/NetworkDrivers/
+
+build_dasharopayloadpkg_64 -b RELEASE
+build_dasharopayloadpkg_64 -b DEBUG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,13 @@ jobs:
           coreboot/coreboot-sdk:2024-02-18_732134932b \
          ./.github/scripts/build-ipxe.sh
 
+    - name: Build DasharoPayloadPkg
+      run: |
+        docker run --rm -i -v $PWD:/home/coreboot/coreboot:rw \
+          -u $(id -u):$(id -g) -w /home/coreboot/coreboot \
+          coreboot/coreboot-sdk:2024-02-18_732134932b \
+         ./.github/scripts/build-dasharo-payload-pkg.sh
+
     - name: Build OVMF Firmware Image
       run: |
         docker run --rm -i -v $PWD:/home/coreboot/coreboot:rw \

--- a/DasharoPayloadPkg/DasharoPayloadPkg.fdf
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.fdf
@@ -397,7 +397,7 @@ INF  RuleOverride = BINARY USE = X64 ShellBinPkg/UefiShell/UefiShell.inf
 # without forking.
 FILE DRIVER = CAB058DF-E938-4F85-8978-1F7E6AABDB96 {
   SECTION DXE_DEPEX_EXP = {gEfiGraphicsOutputProtocolGuid AND gEfiSimpleTextInputExProtocolGuid AND NOT gDasharoFastBootPolicyGuid}
-  SECTION PE32 = Build/DasharoPayloadPkgX64/$(TARGET)_COREBOOT/X64/CrScreenshotDxe.efi
+  SECTION PE32 = Build/DasharoPayloadPkgX64/$(TARGET)_$(TOOLCHAIN)/X64/CrScreenshotDxe.efi
   SECTION UI = "CrScreenshotDxe"
 }
 


### PR DESCRIPTION
# Description

Extend build workflow with build test of DasharoPayloadPkg

.github/scripts/build-dasharo-payload-pkg-qemu.sh: Implement building both RELEASE and DEBUG variants

.github/workflows/build.yml:
Add a job that runs the build script

DasharoPayloadPkg/DasharoPayloadPkg.fdf:
Fix the build not proceeding due to the expectation of the file `/home/coreboot/coreboot/Build/\
DasharoPayloadPkgX64/DEBUG_COREBOOT/X64/CrScreenshotDxe.efi` when using GCC5, rather than assumed COREBOOT, plus its RELEASE equivalent.

Resolves https://github.com/Dasharo/dasharo-issues/issues/1339

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

An [automatically-triggered GitHub Action](https://github.com/aronowski/edk2/actions/runs/15045527023/job/42286981770) resulted in all workflows passing

## Integration Instructions

N/A
