### PR TITLE
SecureBootConfigDxe: Implement parsing missing hashes

### DIFF
--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
@@ -76,11 +76,19 @@
 
   ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
   ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
+  gEfiCertRsa2048Sha256Guid
+
+  ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
   gEfiCertX509Guid
 
   ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
   ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
   gEfiCertSha1Guid
+
+  ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
+  gEfiCertSha224Guid
 
   ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
   ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
@@ -93,6 +101,10 @@
   ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
   ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
   gEfiCertSha512Guid
+
+  ## SOMETIMES_CONSUMES      ## GUID            # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES      ## GUID            # Unique ID for the type of the signature.
+  gEfiCertSm3Guid
 
   ## SOMETIMES_CONSUMES      ## Variable:L"db"
   ## SOMETIMES_PRODUCES      ## Variable:L"db"
@@ -118,6 +130,7 @@
   gEfiCertX509Sha256Guid                        ## SOMETIMES_PRODUCES  ## GUID  # Unique ID for the type of the certificate.
   gEfiCertX509Sha384Guid                        ## SOMETIMES_PRODUCES  ## GUID  # Unique ID for the type of the certificate.
   gEfiCertX509Sha512Guid                        ## SOMETIMES_PRODUCES  ## GUID  # Unique ID for the type of the certificate.
+  gEfiCertX509Sm3Guid                        ## SOMETIMES_PRODUCES  ## GUID  # Unique ID for the type of the certificate.
 
 [Protocols]
   gEfiHiiConfigAccessProtocolGuid               ## PRODUCES

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -2552,9 +2552,12 @@ UpdateDeletePage (
   CHAR8               *CertificateInfoStr8;
   EFI_STRING_ID       CertificateInfoID;
   EFI_STRING_ID       Help;
+  CHAR16              *FormatNameString;
   UINTN               CertificateInfoStrSize;
   CHAR16              *UnknownCert;
   RETURN_STATUS       RStatus;
+  CHAR16              *NameString;
+  EFI_STRING_ID       NameStringId;
 
   Data                    = NULL;
   CertList                = NULL;
@@ -2563,6 +2566,8 @@ UpdateDeletePage (
   CertificateInfoStr8     = NULL;
   StartOpCodeHandle       = NULL;
   EndOpCodeHandle         = NULL;
+  NameString              = NULL;
+  FormatNameString        = NULL;
   CertificateInfoStrSize  = 0;
   UnknownCert             = L"Unknown Certificate: No Common Name, No Issuer";
   RStatus                 = RETURN_SUCCESS;
@@ -2631,15 +2636,8 @@ UpdateDeletePage (
   GuidIndex    = 0;
 
   while ((ItemDataSize > 0) && (ItemDataSize >= CertList->SignatureListSize)) {
-    if (CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertSha1Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertSha256Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha256Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha384Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid)
-        )
-    {
+    if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
+      /* Handle certificates */
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
       for (Index = 0; Index < CertCount; Index++) {
         Cert = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList
@@ -2703,10 +2701,77 @@ UpdateDeletePage (
         CertificateInfoStr8 = NULL;
         CertificateInfoStr = NULL;
       }
+    } else if (CompareGuid (&CertList->SignatureType, &gEfiCertSha1Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertSha224Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertSha256Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertSha384Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertSha512Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertSm3Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha256Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha384Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertX509Sm3Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Guid) ||
+               CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Sha256Guid) 
+              )
+    {
+      /* Handle image hashes or certificate hashes */
+      CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
+      for (Index = 0; Index < CertCount; Index++) {
+        Cert = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList
+                                      + sizeof (EFI_SIGNATURE_LIST)
+                                      + CertList->SignatureHeaderSize
+                                      + Index * CertList->SignatureSize);
 
-      ItemDataSize -= CertList->SignatureListSize;
-      CertList      = (EFI_SIGNATURE_LIST *)((UINT8 *)CertList + CertList->SignatureListSize);
+        if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha256Guid) ||
+            CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha384Guid) ||
+            CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid) ||
+            CompareGuid (&CertList->SignatureType, &gEfiCertX509Sm3Guid)
+           )
+        {
+          FormatNameString = HiiGetString (PrivateData->HiiHandle, STRING_TOKEN (STR_SIGNATURE_CERT_HASH_NAME_FORMAT), NULL);
+        } else if (CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Sha256Guid)) {
+          FormatNameString = HiiGetString (PrivateData->HiiHandle, STRING_TOKEN (STR_SIGNATURE_DATA_RSA_HASH_NAME_FORMAT), NULL);
+        } else if (CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Guid)) {
+          FormatNameString = HiiGetString (PrivateData->HiiHandle, STRING_TOKEN (STR_SIGNATURE_DATA_RSA_NAME_FORMAT), NULL);
+        } else {
+          FormatNameString = HiiGetString (PrivateData->HiiHandle, STRING_TOKEN (STR_SIGNATURE_DATA_HASH_NAME_FORMAT), NULL);
+        }
+
+        if (FormatNameString == NULL) {
+          goto ON_EXIT;
+        }
+
+        NameString = AllocateZeroPool (BUFFER_MAX_SIZE + StrLen(FormatNameString) * sizeof(CHAR16));
+        if (NameString == NULL) {
+          Status = EFI_OUT_OF_RESOURCES;
+          goto ON_EXIT;
+        }
+
+        UnicodeSPrint (NameString, BUFFER_MAX_SIZE + StrLen(FormatNameString) * sizeof(CHAR16), FormatNameString, &Cert->SignatureOwner),
+        NameStringId = HiiSetString (PrivateData->HiiHandle, 0, NameString, NULL);
+
+        Status = FormatHelpInfo (PrivateData, CertList, Cert, &Help);
+        if (!EFI_ERROR (Status)) {
+          HiiCreateCheckBoxOpCode (
+            StartOpCodeHandle,
+            (EFI_QUESTION_ID)(QuestionIdBase + GuidIndex++),
+            0,
+            0,
+            NameStringId,
+            Help,
+            EFI_IFR_FLAG_CALLBACK | EFI_IFR_FLAG_RESET_REQUIRED,
+            0,
+            NULL
+            );
+        }
+      }
+    } else {
+      DEBUG ((EFI_D_WARN, "%a(): Unhandled Cert Type: %g\n", __FUNCTION__, &CertList->SignatureType));
     }
+
+    ItemDataSize -= CertList->SignatureListSize;
+    CertList      = (EFI_SIGNATURE_LIST *)((UINT8 *)CertList + CertList->SignatureListSize);
   }
 
 ON_EXIT:
@@ -2736,6 +2801,10 @@ ON_EXIT:
 
   if (CertificateInfoStr8 != NULL) {
     FreePool (CertificateInfoStr8);
+  }
+
+  if (NameString != NULL) {
+    FreePool (NameString);
   }
 
   return EFI_SUCCESS;
@@ -3029,10 +3098,15 @@ DeleteSignature (
     if (CompareGuid (&CertList->SignatureType, &gEfiCertRsa2048Guid) ||
         CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid) ||
         CompareGuid (&CertList->SignatureType, &gEfiCertSha1Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertSha224Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertSha384Guid) ||
         CompareGuid (&CertList->SignatureType, &gEfiCertSha256Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertSha512Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertSm3Guid) ||
         CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha256Guid) ||
         CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha384Guid) ||
-        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid)
+        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sha512Guid) ||
+        CompareGuid (&CertList->SignatureType, &gEfiCertX509Sm3Guid)
         )
     {
       //
@@ -3834,23 +3908,31 @@ LoadSignatureList (
   ListWalker    = (EFI_SIGNATURE_LIST *)VariableData;
   while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize)) {
     if (CompareGuid (&ListWalker->SignatureType, &gEfiCertRsa2048Guid)) {
+      ListType = STRING_TOKEN (STR_LIST_TYPE_RSA2048);
+    } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertRsa2048Sha256Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_RSA2048_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_X509);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertSha1Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_SHA1);
+    } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertSha224Guid)) {
+      ListType = STRING_TOKEN (STR_LIST_TYPE_SHA224);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertSha256Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertSha384Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_SHA384);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertSha512Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_SHA512);
+    } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertSm3Guid)) {
+      ListType = STRING_TOKEN (STR_LIST_TYPE_SM3);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Sha256Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_X509_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Sha384Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_X509_SHA384);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Sha512Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_X509_SHA512);
+    } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Sm3Guid)) {
+      ListType = STRING_TOKEN (STR_LIST_TYPE_X509_SM3);
     } else {
       ListType = STRING_TOKEN (STR_LIST_TYPE_UNKNOWN);
     }
@@ -4079,9 +4161,11 @@ FormatHelpInfo (
   IsCert           = FALSE;
 
   if (CompareGuid (&ListEntry->SignatureType, &gEfiCertRsa2048Guid)) {
+    ListTypeId = STRING_TOKEN (STR_LIST_TYPE_RSA2048);
+    DataSize   = ListEntry->SignatureSize - sizeof (EFI_GUID);
+  } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertRsa2048Sha256Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_RSA2048_SHA256);
     DataSize   = ListEntry->SignatureSize - sizeof (EFI_GUID);
-    IsCert     = TRUE;
   } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertX509Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_X509);
     DataSize   = ListEntry->SignatureSize - sizeof (EFI_GUID);
@@ -4089,6 +4173,9 @@ FormatHelpInfo (
   } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertSha1Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_SHA1);
     DataSize   = 20;
+  } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertSha224Guid)) {
+    ListTypeId = STRING_TOKEN (STR_LIST_TYPE_SHA224);
+    DataSize   = 28;
   } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertSha256Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_SHA256);
     DataSize   = 32;
@@ -4098,6 +4185,9 @@ FormatHelpInfo (
   } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertSha512Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_SHA512);
     DataSize   = 64;
+  } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertSm3Guid)) {
+    ListTypeId = STRING_TOKEN (STR_LIST_TYPE_SM3);
+    DataSize   = 32;
   } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertX509Sha256Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_X509_SHA256);
     DataSize   = 32;
@@ -4109,6 +4199,10 @@ FormatHelpInfo (
   } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertX509Sha512Guid)) {
     ListTypeId = STRING_TOKEN (STR_LIST_TYPE_X509_SHA512);
     DataSize   = 64;
+    Time       = (EFI_TIME *)(DataEntry->SignatureData + DataSize);
+  } else if (CompareGuid (&ListEntry->SignatureType, &gEfiCertX509Sm3Guid)) {
+    ListTypeId = STRING_TOKEN (STR_LIST_TYPE_X509_SM3);
+    DataSize   = 32;
     Time       = (EFI_TIME *)(DataEntry->SignatureData + DataSize);
   } else {
     Status = EFI_UNSUPPORTED;
@@ -4183,7 +4277,7 @@ FormatHelpInfo (
     UnicodeSPrint (
       TimeString,
       sizeof (TimeString),
-      L"%d-%d-%d %d:%d:%d",
+      L"%04d-%02d-%02d %02d:%02d:%02d",
       Time->Year,
       Time->Month,
       Time->Day,
@@ -4370,7 +4464,7 @@ LoadSignatureData (
       NULL
       );
 
-    ZeroMem (NameBuffer, 100);
+    ZeroMem (NameBuffer, BUFFER_MAX_SIZE);
     DataWalker = (EFI_SIGNATURE_DATA *)((UINT8 *)DataWalker + ListWalker->SignatureSize);
   }
 
@@ -4679,7 +4773,7 @@ SecureBootCallback (
   CHAR16                          *PkCN16;
   UINT8                           *SecureBootMode;
   UINT8                           *SetupMode;
-  CHAR16                          PromptString[100];
+  CHAR16                          PromptString[BUFFER_MAX_SIZE];
   EFI_DEVICE_PATH_PROTOCOL        *File;
   UINTN                           NameLength;
   UINT16                          *FilePostFix;
@@ -4689,6 +4783,7 @@ SecureBootCallback (
   EFI_HII_POPUP_PROTOCOL          *HiiPopup;
   EFI_HII_POPUP_SELECTION         UserSelection;
   CHAR16                          *UnknownCert;
+  EFI_STRING                      PkString;
 
   Status               = EFI_SUCCESS;
   RStatus              = RETURN_SUCCESS;
@@ -4738,42 +4833,54 @@ SecureBootCallback (
 
         GetVariable2 (EFI_PLATFORM_KEY_NAME, &gEfiGlobalVariableGuid, (VOID **)&PkList, NULL);
         if (PkList != NULL) {
-          // Extract the PK certificate from the list
-          PkCert = (EFI_SIGNATURE_DATA *)((UINT8 *)PkList + sizeof (EFI_SIGNATURE_LIST) + PkList->SignatureHeaderSize);
+          if (CompareGuid (&PkList->SignatureType, &gEfiCertRsa2048Guid)) {
+            PkString = HiiGetString (Private->HiiHandle, STRING_TOKEN (STR_LIST_TYPE_RSA2048), NULL);
+            HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), PkString, NULL);
+          } else if (CompareGuid (&PkList->SignatureType, &gEfiCertX509Guid)) {
+            // Extract the PK certificate from the list
+            PkCert = (EFI_SIGNATURE_DATA *)((UINT8 *)PkList + sizeof (EFI_SIGNATURE_LIST) + PkList->SignatureHeaderSize);
 
-          // Get the required buffer size
-          UINTN cnSize = 0;
-          X509GetCommonName (
-            (UINT8*)PkCert->SignatureData,
-            (UINTN)PkList->SignatureSize,
-            NULL,
-            &cnSize
-            );
+            // Get the required buffer size
+            UINTN cnSize = 0;
+            X509GetCommonName (
+              (UINT8*)PkCert->SignatureData,
+              (UINTN)PkList->SignatureSize,
+              NULL,
+              &cnSize
+              );
 
-          PkCN8 = AllocateZeroPool (cnSize * sizeof(CHAR8));
-          if (PkCN8 == NULL) {
-            Status = EFI_OUT_OF_RESOURCES;
-            goto EXIT;
-          }
-          PkCN16 = AllocateZeroPool (cnSize * sizeof(CHAR16));
-          if (PkCN16 == NULL) {
-            Status = EFI_OUT_OF_RESOURCES;
-            goto EXIT;
-          }
+            PkCN8 = AllocateZeroPool (cnSize * sizeof(CHAR8));
+            if (PkCN8 == NULL) {
+              Status = EFI_OUT_OF_RESOURCES;
+              goto EXIT;
+            }
+            PkCN16 = AllocateZeroPool (cnSize * sizeof(CHAR16));
+            if (PkCN16 == NULL) {
+              Status = EFI_OUT_OF_RESOURCES;
+              goto EXIT;
+            }
 
-          RStatus = X509GetCommonName (
-            (UINT8*)PkCert->SignatureData,
-            (UINTN)PkList->SignatureSize,
-            PkCN8,
-            &cnSize
-            );
+            RStatus = X509GetCommonName (
+              (UINT8*)PkCert->SignatureData,
+              (UINTN)PkList->SignatureSize,
+              PkCN8,
+              &cnSize
+              );
 
-          if (!EFI_ERROR (RStatus)) {
-            AsciiStrToUnicodeStrS (PkCN8, PkCN16, cnSize);
-            HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), PkCN16, NULL);
+            if (!EFI_ERROR (RStatus)) {
+              AsciiStrToUnicodeStrS (PkCN8, PkCN16, cnSize);
+              HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), PkCN16, NULL);
+            } else {
+              HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), UnknownCert, NULL);
+            }
           } else {
-            HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), UnknownCert, NULL);
+            // PK is recommended to be a X509 or an RSA2048. But if other
+            // Signature Type is enrolled here, display a different string:
+            HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), L"Unknown PK type", NULL);
           }
+        } else {
+          // No PK
+          HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_PK_NAME), L"None", NULL);
         }
       }
 

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigStrings.uni
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigStrings.uni
@@ -132,14 +132,18 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #string STR_CERT_TYPE_X509_SHA512_GUID            #language en-US "X509_SHA512_GUID"
 
 #string STR_LIST_TYPE_RSA2048_SHA256              #language en-US "RSA2048_SHA256"
+#string STR_LIST_TYPE_RSA2048                     #language en-US "RSA2048"
 #string STR_LIST_TYPE_X509                        #language en-US "X509"
 #string STR_LIST_TYPE_SHA1                        #language en-US "SHA1"
+#string STR_LIST_TYPE_SHA224                      #language en-US "SHA224"
 #string STR_LIST_TYPE_SHA256                      #language en-US "SHA256"
 #string STR_LIST_TYPE_SHA384                      #language en-US "SHA384"
 #string STR_LIST_TYPE_SHA512                      #language en-US "SHA512"
+#string STR_LIST_TYPE_SM3                         #language en-US "SM3"
 #string STR_LIST_TYPE_X509_SHA256                 #language en-US "X509_SHA256"
 #string STR_LIST_TYPE_X509_SHA384                 #language en-US "X509_SHA384"
 #string STR_LIST_TYPE_X509_SHA512                 #language en-US "X509_SHA512"
+#string STR_LIST_TYPE_X509_SM3                    #language en-US "X509_SM3"
 #string STR_LIST_TYPE_UNKNOWN                     #language en-US "UnKnown"
 
 #string STR_SIGNATURE_LIST_NAME_FORMAT            #language en-US "Signature List, Entry-%d"
@@ -149,5 +153,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #string STR_SIGNATURE_DATA_HELP_FORMAT_CN         #language en-US "%s(%d bytes):\nCN = %s\n"
 #string STR_SIGNATURE_DATA_HELP_FORMAT_HASH       #language en-US "%s(%d bytes):\n%s\n"
 #string STR_SIGNATURE_DATA_HELP_FORMAT_TIME       #language en-US "Revocation Time:\n%s"
+#string STR_SIGNATURE_DATA_HASH_NAME_FORMAT       #language en-US "Image hash %g"
+#string STR_SIGNATURE_CERT_HASH_NAME_FORMAT       #language en-US "Certificate hash %g"
+#string STR_SIGNATURE_DATA_RSA_NAME_FORMAT        #language en-US "RSA2048 key %g"
+#string STR_SIGNATURE_DATA_RSA_HASH_NAME_FORMAT   #language en-US "RSA2048 SHA256 hash %g"
 
 #string STR_SIGNATURE_DELETE_ALL_CONFIRM          #language en-US "Press 'Y' to delete all signature List."


### PR DESCRIPTION
Some hashes were simply ignored (lack of all CompareGuid in conditions) and it caused the browser to enter an infinite loop. Because CertList variable was never updated, the exit condition for the while loop never met.

Also add formatting for displaying image hashes or certificate hashes instead of prue GUIDs.

Fixes https://github.com/Dasharo/dasharo-issues/issues/1365

TEST=Enroll DTS grubx64.efi to DB then delete its signature from DB using the Secure Boot menu on QEMU OVMF.