### PR TITLE
Improve reading full flash on capsule updates

### DIFF
--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -981,7 +981,7 @@ FmpDeviceSetImageWithStatus (
       "%a(): failed to read current firmware\n",
       __FUNCTION__
       ));
-    return EFI_OUT_OF_RESOURCES;
+    return EFI_END_OF_MEDIA;
   }
 
   IncrementProgress (Progress, TotalSteps, ReadSteps, &Step, &ShouldReportProgress);

--- a/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.c
+++ b/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.c
@@ -64,6 +64,12 @@ CallSmm (
     return EFI_UNSUPPORTED;
   }
 
+  DEBUG ((
+    DEBUG_ERROR,
+    "%a: Unexpected response from SMM: 0x%x\n",
+    __FUNCTION__,
+    Result
+    ));
   return EFI_DEVICE_ERROR;
 }
 

--- a/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.c
+++ b/DasharoPayloadPkg/Library/SmmStoreLib/SmmStore.c
@@ -55,7 +55,7 @@ CallSmm (
   CONST UINTN  Rbx = Arg;
   UINTN        Result;
 
-  Result = TriggerSmi (Rax, Rbx, 5);
+  Result = TriggerSmi (Rax, Rbx, 10);
   if (Result == Rax) {
     return EFI_NO_RESPONSE;
   } else if (Result == SMMSTORE_RET_SUCCESS) {

--- a/DasharoPayloadPkg/Library/SmmStoreLib/X64/SmmStore.nasm
+++ b/DasharoPayloadPkg/Library/SmmStoreLib/X64/SmmStore.nasm
@@ -33,6 +33,14 @@ ASM_PFX(TriggerSmi):
 ; As there's no livesign from SMM, just wait a bit for the handler to fire,
 ; and then try again.
 
+; There is a chance that adding NOPs has the effect of increasing the
+; probability of success. The reasoning is that SMI might not happen if an
+; interrupt occurs due to IRET in the handler suppressing the SMI, thus extra
+; instructions could give the interrupt a higher chance of being processed.
+    nop
+    nop
+    nop
+
     cmp     rax, rcx                    ; Check if rax was modified by SMM
     jne     @Return                     ; SMM modified rax, return now
     push    rcx                         ; save rcx to stack


### PR DESCRIPTION
* Use a more rare (and no less applicable) error code to report an issue with reading current firmware.  This is should make failure easier to understand.
* Double the number of retries on calling into SMM to avoid getting `EFI_NO_RESPONSE`.

This is part of fixing https://github.com/Dasharo/dasharo-issues/issues/1338.

coreboot part: https://github.com/Dasharo/coreboot/pull/700

*ref: ncm-1850*