### PR TITLE
Handle FUM for capsule updates even when otherwise unsupported

### DIFF
--- a/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1600,8 +1600,8 @@ PlatformBootManagerAfterConsole (
 
   WarnIfBatteryLow ();
   WarnIfRecoveryBoot ();
-  FUMEnabled = PcdGetBool (PcdShowFum) && WarnIfFirmwareUpdateMode ();
-
+  FUMEnabled = (PcdGetBool (PcdShowFum) || GetBootModeHob () == BOOT_ON_FLASH_UPDATE)
+            && WarnIfFirmwareUpdateMode ();
 
   BootLogoEnableLogo ();
 

--- a/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthVariableLib.c
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "AuthServiceInternal.h"
 #include <DasharoOptions.h>
+#include <Library/HobLib.h>
 
 ///
 /// Global database array for scratch
@@ -248,8 +249,10 @@ AuthVariableLibInitialize (
     SecureBootMode = SECURE_BOOT_MODE_DISABLE;
   }
 
-  // Disable Secure Boot if FUM enabled in the project and currently active
-  if (PcdGetBool (PcdShowFum) && !EFI_ERROR (Status))
+  //
+  // Disable Secure Boot if FUM enabled is in effect.
+  //
+  if ((PcdGetBool (PcdShowFum) || GetBootModeHob () == BOOT_ON_FLASH_UPDATE) && !EFI_ERROR (Status))
     SecureBootMode = SECURE_BOOT_MODE_DISABLE;
 
   Status = AuthServiceInternalUpdateVariable (


### PR DESCRIPTION
Protectli doesn't have FUM, but capsules rely on it to disable firmware protections.  We basically want the functionality without the menus, so I simply added boot mode check next to PCD check.  Same is done for coreboot in https://github.com/Dasharo/coreboot/pull/703

*ref: prot-1829*