### PR TITLE
DasharoPayloadPkg: Add VirtIO drivers build for QEMU

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -189,6 +189,11 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   PciCf8Lib|MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf
   PciLib|DasharoPayloadPkg/Library/BasePciLibPciExpress/BasePciLibPciExpress.inf
+!if $(QEMU_PLATFORM) == TRUE # Needed for Virtio10.inf in QEMU
+  PciCapLib|OvmfPkg/Library/BasePciCapLib/BasePciCapLib.inf
+  PciCapPciIoLib|OvmfPkg/Library/UefiPciCapPciIoLib/UefiPciCapPciIoLib.inf
+  VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf
+!endif
   PciExpressLib|DasharoPayloadPkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   PciSegmentLib|MdePkg/Library/BasePciSegmentLibPci/BasePciSegmentLibPci.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
@@ -394,6 +399,7 @@
   LaptopLidLib|DasharoPayloadPkg/Library/LaptopLidLib/LaptopLidLibNull.inf
 !endif
 !endif
+OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
 
 [LibraryClasses.IA32.SEC]
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
@@ -735,13 +741,19 @@
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
 
 [Components.X64]
+!if $(QEMU_PLATFORM) == TRUE
+  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
+  OvmfPkg/Virtio10Dxe/Virtio10.inf
+  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
+  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
+!endif
+
   #
   # DXE Core
   #
   MdeModulePkg/Core/Dxe/DxeMain.inf {
     <LibraryClasses>
       NULL|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
-      OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
   }
 
   #
@@ -1082,7 +1094,6 @@
     <LibraryClasses>
       DebugLib|MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
       HandleParsingLib|ShellPkg/Library/UefiHandleParsingLib/UefiHandleParsingLib.inf
-      OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
       PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
       ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
       ShellCommandLib|ShellPkg/Library/UefiShellCommandLib/UefiShellCommandLib.inf

--- a/DasharoPayloadPkg/DasharoPayloadPkg.fdf
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.fdf
@@ -115,6 +115,10 @@ INF  MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
 !endif
 !if $(QEMU_PLATFORM) == TRUE
 INF OvmfPkg/LocalApicTimerDxe/LocalApicTimerDxe.inf
+INF OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
+INF OvmfPkg/Virtio10Dxe/Virtio10.inf
+INF OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
+INF OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 !else
 INF PcAtChipsetPkg/HpetTimerDxe/HpetTimerDxe.inf
 !endif


### PR DESCRIPTION
Add VirtIO drivers build for QEMU. Conditionally include module definitions for VirtIO drivers and their dependencies for q35 mainboard (`[Components.X64]` only).

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

As a proof that the drivers are built for QEMU and active, these coreboot runs are attached:
- https://github.com/aronowski/coreboot/actions/runs/15879961202
- https://github.com/aronowski/coreboot/actions/runs/15880467829

as well as [the suggestion by @philipanda](https://github.com/Dasharo/dasharo-issues/issues/901#issuecomment-2979606056):

> The DoD says to attach the `logs of newly developed test, proving VirtIO driver is visible in firmware`. The new test is not required to test the changes in EDK2 & coreboot, because the `esp-scanning.robot` test does that incidentally.

In the [first run](https://github.com/aronowski/coreboot/actions/runs/15879961202) you can see in the build_q35 jobs, that the relevant VirtIO drivers are built for [X64] and tested with [my OSFV fork](https://github.com/aronowski/open-source-firmware-validation/commit/11a313dfcf86ec1016be7f5981b8847b5972c5c3), where `if=virtio` is used instead of `if=ide`, and the `esp-scanning.robot` test suite passes.

In the [second run](https://github.com/aronowski/coreboot/actions/runs/15880467829) I intentionally broke the test_q35 job by trying to run `esp-scanning.robot` using my OSFV revision with forced `if=virtio` and [the edk2 revision prior to this PR (without VirtIO drivers)](https://github.com/aronowski/coreboot/commit/6bb7c73ae093abc751fe156b911bcad1d9365dbb), further proving that the drivers get built and are visible in firmware as per the current PR.



If, despite the suggestion and the justification above, the `esp-scanning.robot` test suite is not sufficient to fulfill the DoD, and a new test is indeed needed, I can provide one in the future.

## Integration Instructions

This is the first PR to partially resolve https://github.com/Dasharo/dasharo-issues/issues/901, [as suggested](https://github.com/Dasharo/dasharo-issues/issues/901#issuecomment-2979606056):

> Two PRs are needed and the one to EDK2 should be merged first.

[This](https://github.com/aronowski/edk2/actions/runs/15878283324) is the revision of edk2 with a modified GitHub Workflow, so that the pushes to my branch are built, as a proof that it builds fine in the first place.

Integration-wise, this PR shall be self-sufficient and non-breaking in the context of edk2, i.e. the coreboot and OSFV changes shall be integrated in the future after some minor changes, like commit titles.
