### PR TITLE
Fix file explorer empty statement

### DIFF
--- a/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
+++ b/MdeModulePkg/Library/FileExplorerLib/FileExplorer.c
@@ -1347,10 +1347,11 @@ LibUpdateFileExplorePage (
         EFI_IFR_FLAG_CALLBACK,
         (UINT16)(mNewFolderQuestionId++)
         );
-      HiiCreateTextOpCode (
+      HiiCreateSubTitleOpCode (
         mLibStartOpCodeHandle,
         STRING_TOKEN (STR_NULL_STRING),
         STRING_TOKEN (STR_NULL_STRING),
+        0,
         0
         );
       CreateNewFile = TRUE;

--- a/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c
@@ -2080,11 +2080,14 @@ DisplayMenuString (
     return;
   }
 
-  //
-  // Print the highlight menu string.
-  // First print the highlight string.
-  //
-  SetDisplayAttribute (MenuOption, TRUE);
+  // Only highlight non-empty strings
+  Highlight = StrLen(MenuOption->Description) != 0;
+  // Sometimes empty strings are defined as single character strings with space
+  if (StrLen(MenuOption->Description) == 1 && MenuOption->Description[0] == L' ') {
+    Highlight = FALSE;
+  }
+
+  SetDisplayAttribute (MenuOption, Highlight);
   Length = PrintStringAt (Col, Row, String);
 
   //


### PR DESCRIPTION
Fixes the bug where the test have to press an extra arrow in the File Explorer:

```
Execute File In File Explorer
    [Documentation]    Execute the given file (with ENTER key)
    [Arguments]    ${target_file}
    # 1. Select desired file
    ${files}=    Get Submenu Construction
    Log    ${files}
    ${index}=    Get Index Of Matching Option In Menu    ${files}    ${target_file}
    # FIXME: We must add 1 due to empty selecatble space in File Manager
    Press Key N Times And Enter    ${index}+1    ${ARROW_DOWN}
```

There was an empty string text statement between the directory/file creation and the list of file/directories, which was selectable. Change this statement to subtitle, which is not selectable, to fix the problem.

Also disallow highlighting empty strings or strings containing a single space character. This will additionally allow to put empty statements into forms that are not supposed to highlight any entry by default when entered.