### PR TITLE
DasharoVariablesLib: warn if ME is in wrong mode for capsule

### DIFF
--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -598,7 +598,12 @@ DasharoCapsulesCanPersistAcrossReset (
   // update.  A more reliable solution would be to pass this information from
   // coreboot.
   //
-  return MeMode == DASHARO_ME_MODE_DISABLE_HAP;
+  if (MeMode != DASHARO_ME_MODE_DISABLE_HAP) {
+    Print (L"[FIRMWARE WARNING] Capsule updates are only supported while Intel ME is in HAP mode!\n");
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 EFI_STATUS


### PR DESCRIPTION
# Description

When capsules are not supported due to ME being on, display a message to tell the user what they need to to to enable capsule update.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

<img width="1000" height="750" alt="image" src="https://github.com/user-attachments/assets/172e3213-11ea-4f46-b227-3c8039aeb104" />
<img width="1000" height="750" alt="image" src="https://github.com/user-attachments/assets/ee3ef02c-51ca-4b33-9a76-a156e7971d31" />


