### PR TITLE
Several fixes for `GenerateCapsule --decode ...`

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -448,6 +448,8 @@ if __name__ == '__main__':
                 del PayloadField ['OpenSslTrustedPublicCertFile']
             if PayloadJsonDescriptorList[Index].SigningToolPath is None:
                 del PayloadField ['SigningToolPath']
+            if PayloadJsonDescriptorList[Index].DepexExp is None:
+                del PayloadField ['Dependencies']
             Index = Index + 1
         Result = json.dumps (PayloadJson, indent=4, sort_keys=True, separators=(',', ': '))
         with open (OutputJsonFile, 'w') as OutputFile:

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -901,7 +901,7 @@ if __name__ == '__main__':
                                            HashAlgorithm = SinglePayloadDescriptor.HashAlgorithm,
                                            Verbose = args.Verbose
                                            )
-                          else:
+                          elif SinglePayloadDescriptor.UseOpenSsl:
                               CertData = VerifyPayloadOpenSsl (
                                            FmpAuthHeader.Payload + struct.pack ('<Q', FmpAuthHeader.MonotonicCount),
                                            FmpAuthHeader.CertData,

--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -409,8 +409,13 @@ if __name__ == '__main__':
                                             DepexExp
                                             ))
 
-    def GenerateOutputJson (PayloadJsonDescriptorList):
+    def GenerateOutputJson (PayloadJsonDescriptorList, EmbeddedDriverPaths):
         PayloadJson = {
+                          "EmbeddedDrivers" : [
+                              {
+                                  "Driver": DriverPath
+                              }for DriverPath in EmbeddedDriverPaths
+                          ],
                           "Payloads" : [
                               {
                                   "Guid": str(PayloadDescriptor.Guid).upper(),
@@ -791,6 +796,8 @@ if __name__ == '__main__':
             except Exception as Msg:
                 print ('GenerateCapsule: error: ' + str(Msg))
                 sys.exit (1)
+
+        EmbeddedDriverPaths = []
         try:
             Result = UefiCapsuleHeader.Decode (Buffer)
             if len (Result) > 0:
@@ -965,10 +972,12 @@ if __name__ == '__main__':
                         print ('GenerateCapsule: error: can not write embedded driver file {File}'.format (File = EmbeddedDriverPath))
                         sys.exit (1)
 
+                    EmbeddedDriverPaths.append (EmbeddedDriverPath)
+
         except Exception as Msg:
             print ('GenerateCapsule: error: can not decode capsule: ' + str(Msg))
             sys.exit (1)
-        GenerateOutputJson(PayloadJsonDescriptorList)
+        GenerateOutputJson (PayloadJsonDescriptorList, EmbeddedDriverPaths)
         PayloadIndex = 0
         for SinglePayloadDescriptor in PayloadDescriptorList:
             if args.OutputFile is None:


### PR DESCRIPTION
With these fixes result of `--decode` can be used as input to `--encode` without causing errors or requiring modifications to add missing  information (at least when it comes to known errors and missing information...).

coreboot part: https://github.com/Dasharo/coreboot/pull/730

*ref: ncm-1926*