### PR TITLE
Fix Linux capsule-loader

### DIFF
--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -15,6 +15,7 @@
 #include <Library/PcdLib.h>
 #include <Library/TpmMeasurementLib.h>
 #include <Library/UefiLib.h>
+#include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 
 #include <DasharoOptions.h>
@@ -599,7 +600,12 @@ DasharoCapsulesCanPersistAcrossReset (
   // coreboot.
   //
   if (MeMode != DASHARO_ME_MODE_DISABLE_HAP) {
-    Print (L"[FIRMWARE WARNING] Capsule updates are only supported while Intel ME is in HAP mode!\n");
+    //
+    // Print() must not be called when gST->ConOut is not available (e.g., at
+    // runtime phase).
+    //
+    if (gST->ConOut != NULL)
+      Print (L"[FIRMWARE WARNING] Capsule updates are only supported while Intel ME is in HAP mode!\n");
     return FALSE;
   }
 

--- a/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/DasharoModulePkg/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -135,6 +135,7 @@ GetVariableInfo (
   } else if (StrCmp (VarName, DASHARO_VAR_ME_MODE) == 0) {
     Data.Uint8 = FixedPcdGet8 (PcdIntelMeDefaultState);
     Size = sizeof (Data.Uint8);
+    ExtraAttrs = EFI_VARIABLE_RUNTIME_ACCESS;
   } else if (StrCmp (VarName, DASHARO_VAR_NETWORK_BOOT) == 0) {
     Data.Boolean = FixedPcdGetBool (PcdDefaultNetworkBootEnable);
     Size = sizeof (Data.Boolean);


### PR DESCRIPTION
Fix checking for ME being HAP-disabled:
 - don't use `Print()` when it can't work and ends up crashing firmware
 - publish ME mode variable in runtime phase so it can be checked from an OS

coreboot PR: https://github.com/Dasharo/coreboot/pull/741

See https://github.com/Dasharo/dasharo-issues/issues/1471#issuecomment-3167392053 for issue description.

*ref: ncm-1941*