### PR TITLE
DasharoPayloadPkg: recover variable storage damaged by a reboot

### DIFF
--- a/DasharoPayloadPkg/BlSupportPei/BlSupportPei.c
+++ b/DasharoPayloadPkg/BlSupportPei/BlSupportPei.c
@@ -814,7 +814,12 @@ BlPeiEntryPoint (
     DEBUG ((DEBUG_INFO, "Created SMMSTORE info hob\n"));
 
     Status = ValidateFvHeader (&SMMSTOREInfo);
-    if (EFI_ERROR (Status)) {
+    //
+    // gEdkiiFaultTolerantWriteGuid HOB doesn't exist if both working and spare
+    // parts of the variable store are invalid, this is when we need to
+    // initialize it with defaults.
+    //
+    if (EFI_ERROR (Status) && GetFirstGuidHob (&gEdkiiFaultTolerantWriteGuid) == NULL) {
       Status = PeiServicesSetBootMode (BOOT_WITH_DEFAULT_SETTINGS);
       DEBUG ((DEBUG_INFO, "BootMode: Boot with default settings\n"));
       ASSERT_EFI_ERROR (Status);

--- a/DasharoPayloadPkg/BlSupportPei/BlSupportPei.inf
+++ b/DasharoPayloadPkg/BlSupportPei/BlSupportPei.inf
@@ -67,6 +67,7 @@
   gEdkiiNvVarStoreFormattedGuid
   gTcgEventEntryHobGuid
   gTcgEvent2EntryHobGuid
+  gEdkiiFaultTolerantWriteGuid
 
 [Ppis]
   gEfiPeiMasterBootModePpiGuid

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -712,7 +712,9 @@ OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrd
   MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
   MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf
   MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
+  MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 
+  DasharoPayloadPkg/SmmStorePei/SmmStorePei.inf
   DasharoPayloadPkg/BlSupportPei/BlSupportPei.inf
   MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 

--- a/DasharoPayloadPkg/DasharoPayloadPkg.fdf
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.fdf
@@ -46,6 +46,15 @@ INF DasharoPayloadPkg/SecCore/SecCore.inf
 
 INF MdeModulePkg/Core/Pei/PeiMain.inf
 INF MdeModulePkg/Universal/PCD/Pei/Pcd.inf
+#
+# Mind the relative order of these PEIMs:
+#  1. SmmStorePei produces gVariableFlashInfoHobGuid
+#  2. FaultTolerantWritePei consumes gVariableFlashInfoHobGuid through
+#     VariableFlashInfoLib and produces gEdkiiFaultTolerantWriteGuid
+#  3. BlSupportPei consumes gEdkiiFaultTolerantWriteGuid
+#
+INF DasharoPayloadPkg/SmmStorePei/SmmStorePei.inf
+INF MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 INF DasharoPayloadPkg/BlSupportPei/BlSupportPei.inf
 INF MdeModulePkg/Universal/ReportStatusCodeRouter/Pei/ReportStatusCodeRouterPei.inf
 INF MdeModulePkg/Universal/StatusCodeHandler/Pei/StatusCodeHandlerPei.inf

--- a/DasharoPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntime.c
+++ b/DasharoPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntime.c
@@ -6,6 +6,7 @@
 
 **/
 
+#include <Guid/FaultTolerantWrite.h>
 #include <Library/UefiLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -14,6 +15,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/PcdLib.h>
 #include <Library/SmmStoreLib.h>
+#include <Library/HobLib.h>
 
 #include "SmmStoreFvbRuntime.h"
 
@@ -154,6 +156,90 @@ SmmStoreVirtualNotifyEvent (
 }
 
 /**
+  Check whether a flash update was interrupted by a reboot and if so,
+  recover variable storage by completing the operation.
+
+  @param[in]  MmioAddress  MMIO base of the variable storage.
+  @param[in]  BlockSize    Block size of the variable storage.
+
+  @retval EFI_SUCCESS  No recovery needed or it was done successfully.
+  @retval other        Recovery went wrong.
+**/
+STATIC
+EFI_STATUS
+RecoverVariableStorage (
+  IN EFI_PHYSICAL_ADDRESS  MmioAddress,
+  IN UINTN                 BlockSize
+  )
+{
+  EFI_STATUS                            Status;
+  UINTN                                 TargetOffset;
+  UINTN                                 SpareOffset;
+  UINTN                                 Copied;
+  UINTN                                 NumBytes;
+  VOID                                  *Buffer;
+  EFI_HOB_GUID_TYPE                     *GuidHob;
+  FAULT_TOLERANT_WRITE_LAST_WRITE_DATA  *FtwLastWrite;
+
+  GuidHob = GetFirstGuidHob (&gEdkiiFaultTolerantWriteGuid);
+  if (GuidHob == NULL) {
+    DEBUG ((DEBUG_INFO, "%a: Recovery is not needed or not possible.\n", __FUNCTION__));
+    return EFI_SUCCESS;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a: Recovery is needed.\n", __FUNCTION__));
+  FtwLastWrite = GET_GUID_HOB_DATA (GuidHob);
+
+  // Validate alignment assumptions used in the loop below.
+  TargetOffset = FtwLastWrite->TargetAddress - MmioAddress;
+  SpareOffset  = FtwLastWrite->SpareAddress - MmioAddress;
+  if (FtwLastWrite->Length % BlockSize != 0 ||
+      TargetOffset % BlockSize != 0 || SpareOffset % BlockSize != 0) {
+    DEBUG ((DEBUG_ERROR, "%a: Recovery information doesn't match SMMSTORE blocks.\n", __FUNCTION__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Buffer = AllocatePool (BlockSize);
+  if (Buffer == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate a memory for recovery.\n", __FUNCTION__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = EFI_SUCCESS;
+  for (Copied = 0; Copied < FtwLastWrite->Length; Copied += BlockSize) {
+    NumBytes = BlockSize;
+    Status   = SmmStoreLibRead ((SpareOffset + Copied) / BlockSize, 0, &NumBytes, Buffer);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to read flash: %r.\n", __FUNCTION__, Status));
+      break;
+    }
+    if (NumBytes != BlockSize) {
+      DEBUG ((DEBUG_ERROR, "%a: Incomplete flash read: %d != %d.\n", __FUNCTION__, NumBytes, BlockSize));
+      Status = EFI_DEVICE_ERROR;
+      break;
+    }
+
+    Status = SmmStoreLibWrite ((TargetOffset + Copied) / BlockSize, 0, &NumBytes, Buffer);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to write flash: %r.\n", __FUNCTION__, Status));
+      break;
+    }
+    if (NumBytes != BlockSize) {
+      DEBUG ((DEBUG_ERROR, "%a: Incomplete flash write: %d != %d.\n", __FUNCTION__, NumBytes, BlockSize));
+      Status = EFI_DEVICE_ERROR;
+      break;
+    }
+  }
+
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "%a: Recovered variable storage.\n", __FUNCTION__));
+  }
+
+  FreePool (Buffer);
+  return Status;
+}
+
+/**
   The user Entry Point for module SmmStoreFvbRuntimeDxe. The user code starts with this function.
 
   @param[in] ImageHandle    The firmware allocated handle for the EFI image.
@@ -205,6 +291,20 @@ SmmStoreInitialize (
     DEBUG ((DEBUG_ERROR, "%a: Failed to get SmmStore block size\n", __FUNCTION__));
     SmmStoreLibDeinitialize ();
     return Status;
+  }
+
+  Status = RecoverVariableStorage (MmioAddress, BlockSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to recover variable storage.\n", __FUNCTION__));
+    //
+    // Keep going because not much can be done.  One strategy could be wiping whole SMMSTORE
+    // and reboot to start with a clean slate, but that may not work if we ended up here.
+    //
+    // Also, hoping for the best we booted with BOOT_ASSUMING_NO_CONFIGURATION_CHANGES but now
+    // we want BOOT_WITH_DEFAULT_SETTINGS.  It's possible to do something like
+    //   ((EFI_HOB_HANDOFF_INFO_TABLE *)GetHobList ())->BootMode = BOOT_WITH_DEFAULT_SETTINGS;
+    // but it may not be a good idea at this point.
+    //
   }
 
   NvStorageSize = BlockCount * BlockSize;

--- a/DasharoPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntimeDxe.inf
+++ b/DasharoPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntimeDxe.inf
@@ -43,6 +43,7 @@
   gEfiAuthenticatedVariableGuid
   gEfiEventVirtualAddressChangeGuid
   gEdkiiNvVarStoreFormattedGuid     ## PRODUCES ## PROTOCOL
+  gEdkiiFaultTolerantWriteGuid      ## CONSUMES
 
 [Protocols]
   gEfiDevicePathProtocolGuid          ## BY_START

--- a/DasharoPayloadPkg/SmmStorePei/SmmStorePei.c
+++ b/DasharoPayloadPkg/SmmStorePei/SmmStorePei.c
@@ -1,0 +1,95 @@
+/** @file
+  This module installs gVariableFlashInfoHobGuid PPI that serves as a source of
+  information about variable storage for VariableFlashInfoLib.
+
+Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.<BR>
+SPDX-License-Identifier: GPL-2.0-or-later
+
+**/
+
+#include <PiPei.h>
+
+#include <Coreboot.h>
+#include <Guid/VariableFlashInfo.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/PeiServicesLib.h>
+
+EFI_PEI_PPI_DESCRIPTOR  mPpiListVariable = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gVariableFlashInfoHobGuid,
+  NULL
+};
+
+/**
+  Main entry for SMMSTORE PEIM.
+
+  @param[in]  FileHandle              Handle of the file being invoked.
+  @param[in]  PeiServices             Pointer to PEI Services table.
+
+  @retval EFI_SUCCESS  On success.
+  @retval Others       On trouble with SMMSTORE information or PPI.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmStorePeiInitialize (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  EFI_STATUS           Status;
+  SMMSTORE_INFO        SmmStoreInfo;
+  VARIABLE_FLASH_INFO  VariableFlashInfo;
+  UINT32               NvStorageBase;
+  UINT32               NvStorageSize;
+  UINT32               NvVariableSize;
+  UINT32               FtwWorkingSize;
+  UINT32               FtwSpareSize;
+
+  Status = ParseSMMSTOREInfo (&SmmStoreInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "SmmStorePei: ParseSMMSTOREInfo() failed: %r.\n",
+      Status
+      ));
+    return Status;
+  }
+
+  NvStorageSize = SmmStoreInfo.NumBlocks * SmmStoreInfo.BlockSize;
+  NvStorageBase = SmmStoreInfo.MmioAddress;
+  DEBUG ((
+    DEBUG_INFO,
+    "SmmStorePei: NvStorageBase: 0x%x, NvStorageSize: 0x%x\n",
+    NvStorageBase,
+    NvStorageSize
+    ));
+
+  FtwSpareSize   = (SmmStoreInfo.NumBlocks / 2) * SmmStoreInfo.BlockSize;
+  FtwWorkingSize = SmmStoreInfo.BlockSize;
+  NvVariableSize = NvStorageSize - FtwSpareSize - FtwWorkingSize;
+  if (NvVariableSize >= 0x80000000) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "SmmStorePei: NvStorageSize is too large: 0x%x > 0x80000000.\n",
+      NvVariableSize
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&VariableFlashInfo, sizeof (VariableFlashInfo));
+
+  VariableFlashInfo.Version               = VARIABLE_FLASH_INFO_HOB_VERSION;
+  VariableFlashInfo.NvVariableBaseAddress = NvStorageBase;
+  VariableFlashInfo.NvVariableLength      = NvVariableSize;
+  VariableFlashInfo.FtwSpareBaseAddress   = NvStorageBase + NvVariableSize + FtwWorkingSize;
+  VariableFlashInfo.FtwSpareLength        = FtwSpareSize;
+  VariableFlashInfo.FtwWorkingBaseAddress = NvStorageBase + NvVariableSize;
+  VariableFlashInfo.FtwWorkingLength      = FtwWorkingSize;
+
+  BuildGuidDataHob (&gVariableFlashInfoHobGuid, &VariableFlashInfo, sizeof (VariableFlashInfo));
+  return PeiServicesInstallPpi (&mPpiListVariable);
+}

--- a/DasharoPayloadPkg/SmmStorePei/SmmStorePei.inf
+++ b/DasharoPayloadPkg/SmmStorePei/SmmStorePei.inf
@@ -1,0 +1,42 @@
+## @file
+# PEI Driver for SmmStore.
+#
+# This module installs gVariableFlashInfoHobGuid PPI that serves as a source of
+# information about variable storage for VariableFlashInfoLib.
+#
+# Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmStorePei
+  MODULE_UNI_FILE                = SmmStorePei.uni
+  FILE_GUID                      = 8CC70A5A-51B4-4049-B97E-982B1D7D4049
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = SmmStorePeiInitialize
+
+[Sources]
+  SmmStorePei.c
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  BlParseLib
+  DebugLib
+  HobLib
+  PeiServicesLib
+  PeimEntryPoint
+
+[Guids]
+  gVariableFlashInfoHobGuid  ## PRODUCES
+
+[Depex]
+  TRUE

--- a/DasharoPayloadPkg/SmmStorePei/SmmStorePei.uni
+++ b/DasharoPayloadPkg/SmmStorePei/SmmStorePei.uni
@@ -1,0 +1,14 @@
+// /** @file
+// PEI Driver for SmmStore.
+//
+// This module installs gVariableFlashInfoHobGuid PPI that serves as a source of
+// information about variable storage for VariableFlashInfoLib.
+//
+// Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "This module installs gVariableFlashInfoHobGuid PPI that serves as a source of information about variable storage for VariableFlashInfoLib."
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This module installs gVariableFlashInfoHobGuid PPI that serves as a source of information about variable storage for VariableFlashInfoLib."


### PR DESCRIPTION
FaultTolerateWrite is enabled and employed, but no recovery was performed.  Not even sure how it happens without coreboot, there is something in MdeModulePkg/Universal/Variable/Pei and MdeModulePkg/Universal/Variable/Pei, but operation of tha code isn't obvious.  Either way, it doesn't kick in for coreboot.

Here is how it works:
 1. SmmStorePei uses data from CBMEM to create gVariableFlashInfoHobGuid HOB
 2. FaultTolerantWritePei consumes gVariableFlashInfoHobGuid through VariableFlashInfoLib and produces gEdkiiFaultTolerantWriteGuid
 3. BlSupportPei consumes gEdkiiFaultTolerantWriteGuid and uses it to decide which boot mode to use
 4. When SmmStoreFvbRuntime gets initialized it looks up gEdkiiFaultTolerantWriteGuid and if needed finishes the operation interrupted by a reboot

coreboot part: https://github.com/Dasharo/coreboot/pull/758
fixes: https://github.com/Dasharo/dasharo-issues/issues/1293
*ref: ncm-1969*
