### PR TITLE
SecurityPkg/Tpm2DeviceLibDTpm/Tpm2Ptp.c: work around inaccurate "granted" bit

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -114,10 +114,30 @@ PtpCrbRequestUseTpm (
   IN      PTP_CRB_REGISTERS_PTR  CrbReg
   )
 {
+  UINT32      Locality;
   EFI_STATUS  Status;
 
   if (!Tpm2IsPtpPresence (CrbReg)) {
     return EFI_NOT_FOUND;
+  }
+
+  //
+  // Skip requesting locality if it's already active.  In principle, the first
+  // check should be enough.  However, at least some CRB TPMs can reset the
+  // "granted" bit (and only the bit, active locality is not actually affected)
+  // when going in and out of the Idle state and then do nothing on request to
+  // grant locality, which leads to a timeout below.  One possible explanation
+  // is that the "granted" bit is flipped due to a bug and the chip just does
+  // nothing on requesting access to an already active locality.  The extra
+  // check should do no harm to well-behaving chips.
+  //
+  // Locality is derived from the base address:
+  //   0xFED40000 -> 0, 0xFED41000 -> 1, etc.
+  //
+  Locality = ((UINTN)CrbReg & 0xffff) >> 12;
+  if ((MmioRead32 ((UINTN)&CrbReg->LocalityStatus) & PTP_CRB_LOCALITY_STATUS_GRANTED) ||
+      (MmioRead32 ((UINTN)&CrbReg->LocalityState) & PTP_CRB_LOCALITY_STATE_ACTIVE_LOCALITY_MASK) == Locality) {
+    return EFI_SUCCESS;
   }
 
   MmioWrite32 ((UINTN)&CrbReg->LocalityControl, PTP_CRB_LOCALITY_CONTROL_REQUEST_ACCESS);


### PR DESCRIPTION
Avoid timing out in PtpCrbRequestUseTpm() for weird CRB chips that sometimes reset "granted" bit when switching (or maybe staying) in the Idle state for some time.  The function was waiting for the bit to be set by the TPM which did not do it, so check an active locality and just return if nothing needs to be done.

This has been observed with Intels fTPM on Jasper Lake Protectli V1210 and V1610 devices.

coreboot PR: https://github.com/Dasharo/coreboot/pull/759
*ref: prot-1876*