### PR TITLE
DasharoPayloadPkg/PlatformBootManagerLib: register serial console after VGA

### DIFF
--- a/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -846,12 +846,6 @@ PlatformBootManagerBeforeConsole (
   FilterAndProcess (&gEfiPciRootBridgeIoProtocolGuid, NULL, Connect);
 
   //
-  // PCI initialization from above should be sufficient for the discovery and
-  // processing of consoles.
-  //
-  PlatformConsoleInit ();
-
-  //
   // Find all display class PCI devices (using the handles from the previous
   // step), and connect them non-recursively. This should produce a number of
   // child handles with GOPs on them.
@@ -863,6 +857,18 @@ PlatformBootManagerBeforeConsole (
   // ErrOut.
   //
   FilterAndProcess (&gEfiGraphicsOutputProtocolGuid, NULL, AddOutput);
+
+  //
+  // Connecting children of gEfiPciRootBridgeIoProtocolGuid should be sufficient
+  // for the discovery and processing of consoles, but we intentionally add
+  // serial consoles later to make sure they follow all graphical ones.
+  //
+  // This is because at least some bootloaders (e.g., one in FreeBSD) use the
+  // first console of ConOut as the primary one. Putting serial console first
+  // leads to interactive output going to serial where most users won't even
+  // see it.
+  //
+  PlatformConsoleInit ();
 
   if (mFastBoot) {
     //


### PR DESCRIPTION
At least some bootloaders (e.g., one in FreeBSD) use the first console of ConOut as the primary one. Putting serial console first leads to interactive output going to serial where most users won't even see it.

OVMF and likely other firmware built with EDK put graphical output before the serial, so this shouldn't cause any breakage although some changes in behaviour is possible.

***

Tagging @miczyg1 in case he had a specific reason for adding consoles in this order, although judging by the comment serial was registered when it could be discovered.

***

This addresses  https://github.com/Dasharo/dasharo-issues/issues/1545.
*ref: prot-1908*