### PR TITLE
DasharoPayloadPkg/Library/FmpDeviceSmmLib: Handle read- and write-protected regions

### DIFF
--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -80,7 +80,7 @@ GetFmap (
 VOID *
 EFIAPI
 ReadCurrentFirmware (
-  VOID
+  BOOLEAN IsDescriptorLocked
   )
 {
   EFI_STATUS  Status;
@@ -140,8 +140,15 @@ ReadCurrentFirmware (
         Block * BlockSize,
         Status
         ));
-      FreePool (Image);
-      return NULL;
+
+      // We allow for this failure if descriptor is locked because when locked,
+      // certain regions of the flash are read-protected. We can't know which
+      // ones they are until we've read enough of the firmware to get to the
+      // FMAP.
+      if (!IsDescriptorLocked) {
+        FreePool (Image);
+        return NULL;
+      }
     }
   }
 
@@ -606,6 +613,83 @@ MigrateSmbiosData (
   // TODO: if CONFIG_CBFS_VERIFICATION is on, need to update CBFS hash here
   //       (file can have hashes too, but they seem optional)
   //
+
+  return TRUE;
+}
+
+/**
+  Checks if the given range is writable according to Intel Flash Descriptor
+  access restrictions.
+
+  @param[in] Image       Firmware image to check
+  @param[in] ImageLen    Length of the image
+  @param[in] RangeOffset Offset in the image to check
+  @param[in] RangeLen    Length of the range to check
+
+  @return TRUE if range is writeable, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IsRangeWriteable (
+  IN CONST VOID *Image,
+  IN CONST UINTN ImageLen,
+  IN CONST UINTN RangeOffset,
+  IN CONST UINTN RangeLen
+  )
+{
+  CONST Fmap     *FlashMap;
+  CONST FmapArea *Region;
+
+  // Reject out-of-bounds upfront
+  if (RangeOffset >= ImageLen || RangeLen > ImageLen - RangeOffset)
+    return FALSE;
+
+  // Something went wrong, assume nothing is writable. Update won't touch anything.
+  if (!GetFmap (Image, ImageLen, &FlashMap)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to parse current firmware\n",
+      __FUNCTION__
+      ));
+    return FALSE;
+  }
+
+  // If descriptor is locked, IFD, ME, GbE and DevExp2 regions are not
+  // writeable. This is at least true for Dasharo firmware and TrustRoot
+  // provisioning scripts.
+  Region = FmapFindArea(FlashMap, "SI_DESC");
+
+  // There is no descriptor, so everything should be unlocked.
+  if (!Region)
+    return TRUE;
+
+  // Range overlaps locked descriptor.
+  if (RangeOffset + RangeLen > Region->offset &&
+      Region->offset + Region->size > RangeOffset)
+    return FALSE;
+
+  Region = FmapFindArea(FlashMap, "SI_ME");
+
+  // Range exists and overlaps locked ME.
+  if (Region && RangeOffset + RangeLen > Region->offset &&
+      Region->offset + Region->size > RangeOffset)
+    return FALSE;
+
+  Region = FmapFindArea(FlashMap, "RW_UNUSED");
+
+  // Range exists and overlaps locked RW_UNUSED.
+  if (Region && RangeOffset + RangeLen > Region->offset &&
+      Region->offset + Region->size > RangeOffset)
+    return FALSE;
+
+  Region = FmapFindArea(FlashMap, "SI_GBE");
+
+  // While SI_GBE is not typically locked, its size is smaller than the SMMSTORE
+  // erase/write size, and it sits between two locked regions. Explicitly avoid
+  // touching it to reduce ambiguity.
+  if (Region && RangeOffset + RangeLen > Region->offset &&
+      Region->offset + Region->size > RangeOffset)
+    return FALSE;
 
   return TRUE;
 }

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.h
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.h
@@ -9,7 +9,7 @@
 VOID *
 EFIAPI
 ReadCurrentFirmware (
-  VOID
+  BOOLEAN IsDescriptorLocked
   );
 
 /**
@@ -25,6 +25,25 @@ EFIAPI
 MergeFirmwareImages (
   IN CONST VOID  *Current,
   IN CONST VOID  *New
+  );
+
+/**
+  Checks if the given range overlaps a write-protected IFD range.
+
+  @param[in] Image       Firmware image to check
+  @param[in] ImageLen    Length of the image
+  @param[in] RangeOffset Offset in the image to check
+  @param[in] RangeOffset Length of the range to check
+
+  @return TRUE if range is writeable, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IsRangeWriteable (
+  IN CONST VOID *Image,
+  IN CONST UINTN ImageLen,
+  IN CONST UINTN RangeOffset,
+  IN CONST UINTN RangeLen
   );
 
 #endif // FLASHING_H__

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -881,9 +881,9 @@ IsDescriptorLocked (
 
   // Variable does not exist on platforms without a descriptor (e.g. AMD)
   if (EFI_ERROR(Status))
-    return TRUE;
+    return FALSE;
 
-  return DescriptorWriteable;
+  return !DescriptorWriteable;
 }
 
 /**

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -860,6 +860,32 @@ QueryVariableInfoHook (
   return EFI_NOT_AVAILABLE_YET;
 }
 
+STATIC
+BOOLEAN
+IsDescriptorLocked (
+  VOID
+  )
+{
+  EFI_STATUS     Status;
+  UINTN          VarSize;
+  UINT8          DescriptorWriteable;
+
+  VarSize = sizeof (DescriptorWriteable);
+  Status = gRT->GetVariable (
+      L"DescriptorWriteable",
+      &gDasharoSystemFeaturesGuid,
+      NULL,
+      &VarSize,
+      &DescriptorWriteable
+      );
+
+  // Variable does not exist on platforms without a descriptor (e.g. AMD)
+  if (EFI_ERROR(Status))
+    return TRUE;
+
+  return DescriptorWriteable;
+}
+
 /**
   Updates a firmware device with a new firmware image.  This function returns
   EFI_UNSUPPORTED if the firmware image is not updatable.  If the firmware image
@@ -946,6 +972,7 @@ FmpDeviceSetImageWithStatus (
   UINT8       *CurrentImage;
   UINT8       *UpdatedImage;
   UINTN       Offset;
+  BOOLEAN     DescriptorLocked;
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
 
@@ -974,7 +1001,9 @@ FmpDeviceSetImageWithStatus (
   ReadSteps = (TotalSteps * 5) / 100;
   TotalSteps += ReadSteps;
 
-  CurrentImage = ReadCurrentFirmware ();
+  DescriptorLocked = IsDescriptorLocked();
+
+  CurrentImage = ReadCurrentFirmware (DescriptorLocked);
   if (CurrentImage == NULL) {
     DEBUG ((
       DEBUG_ERROR,
@@ -1005,6 +1034,20 @@ FmpDeviceSetImageWithStatus (
     //
     if (CompareMem (CurrentImage + Offset, UpdatedImage + Offset, BlockSize) == 0) {
       // Erase and write steps.
+      IncrementProgress (Progress, TotalSteps, 2, &Step, &ShouldReportProgress);
+      continue;
+    }
+
+    // Only touch blocks that are fully unlocked for writing.
+    // This assumes that the protected ranges are aligned to SMMSTORE's block
+    // size, otherwise the start/end of unprotected ranges might not get
+    // updated.
+    if (DescriptorLocked && !IsRangeWriteable(CurrentImage, ImageSize, Offset, BlockSize)) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a(): range %d - %d is not writeable\n",
+        __FUNCTION__, Offset, BlockSize + Offset
+        ));
       IncrementProgress (Progress, TotalSteps, 2, &Step, &ShouldReportProgress);
       continue;
     }

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -44,6 +44,10 @@
 
 [Packages]
   DasharoPayloadPkg/DasharoPayloadPkg.dec
+  DasharoModulePkg/DasharoModulePkg.dec
   FmpDevicePkg/FmpDevicePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+
+[Guids]
+  gDasharoSystemFeaturesGuid


### PR DESCRIPTION
Handle locked regions appropriately by:
- Not failing completely if we could not read some of the firmware
- Skipping writes to locked regions

Note that this assumes that the protected ranges are aligned to the erase/write block size, otherwise the start/end of unprotected ranges might not get updated.

It also depends on the FMAP being consistent with the IFD.

*ref: ncm-2076*