### PR TITLE
Report firmware update result to the user

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dec
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dec
@@ -101,3 +101,5 @@ gDasharoPayloadPkgTokenSpaceGuid.PcdSetupMenuKey|0x0017|UINT16|0x00000008
 
 gDasharoPayloadPkgTokenSpaceGuid.PcdPrintSolStrings|FALSE|BOOLEAN|0x0000000A
 gDasharoPayloadPkgTokenSpaceGuid.PcdSerialOnSuperIo|FALSE|BOOLEAN|0x0000000B
+
+gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleReport|FALSE|BOOLEAN|0x0000000C

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -254,6 +254,7 @@
   FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
   FmpDeviceLib|DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
   FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
+  PopUpLib|DasharoPayloadPkg/Library/PopUpLib/PopUpLib.inf
 !else
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.inf
 !endif

--- a/DasharoPayloadPkg/Include/Library/PopUpLib.h
+++ b/DasharoPayloadPkg/Include/Library/PopUpLib.h
@@ -1,0 +1,43 @@
+//
+// A utility library for drawing simple popups.
+//
+// Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+// SPDX-License-Identifier: GPL-2-or-later
+//
+//
+
+#ifndef _POP_UP_LIB_H_
+#define _POP_UP_LIB_H_
+
+typedef enum {
+  ErrorPopUp,
+  SuccessPopUp,
+} PopupKind;
+
+VOID
+EFIAPI
+DrainInput (
+  VOID
+  );
+
+/**
+  Draw a pop up windows based on the dimension, number of lines and
+  strings specified. (GOP Scaled Version)
+
+  @param Kind            Color of the background.
+  @param RequestedWidth  The width of the pop-up in standard character cells.
+                         If 0, autosize to fit longest string.
+  @param NumberOfLines   The number of lines.
+  @param ...             A series of text strings that displayed in the pop-up.
+
+**/
+VOID
+EFIAPI
+DrawGraphicPopUp (
+  IN  PopupKind  Kind,
+  IN  UINTN      RequestedWidth,
+  IN  UINTN      NumberOfLines,
+  ...
+  );
+
+#endif // _POP_UP_LIB_H_

--- a/DasharoPayloadPkg/Include/Library/PopUpLib.h
+++ b/DasharoPayloadPkg/Include/Library/PopUpLib.h
@@ -14,10 +14,67 @@ typedef enum {
   SuccessPopUp,
 } PopupKind;
 
+typedef struct {
+  CHAR16  *Lines[24];
+  UINTN   Length;
+  UINTN   Width;
+} PopUpData;
+
 VOID
 EFIAPI
 DrainInput (
   VOID
+  );
+
+VOID
+EFIAPI
+PopUpInit (
+  OUT PopUpData  *PopUp,
+  IN UINTN       Width
+  );
+
+VOID
+EFIAPI
+AddTitle (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line
+  );
+
+VOID
+EFIAPI
+AddLineF (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Format,
+  ...
+  );
+
+VOID
+EFIAPI
+AddFullLineF (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Format,
+  ...
+  );
+
+VOID
+EFIAPI
+AddLine (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line
+  );
+
+VOID
+EFIAPI
+AddFullLine (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line
+  );
+
+VOID
+EFIAPI
+PopUpDraw (
+  IN CONST PopUpData  *PopUp,
+  IN PopupKind        GuiKind
   );
 
 /**

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -13,18 +13,16 @@
 #include <Guid/SystemResourceTable.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BlParseLib.h>
-#include <Library/CustomizedDisplayLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FmpDeviceLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/PopUpLib.h>
 #include <Library/PrintLib.h>
 #include <Library/SmmStoreLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <PiDxe.h>
-#include <Protocol/GraphicsOutput.h>
-#include <Protocol/HiiFont.h>
 
 #include "Flashing.h"
 
@@ -866,278 +864,6 @@ QueryVariableInfoHook (
 
 STATIC
 VOID
-DrainInput (
-  VOID
-)
-{
-  EFI_INPUT_KEY Key;
-
-  //
-  // Drain any queued keys.
-  //
-  while (!EFI_ERROR (gST->ConIn->ReadKeyStroke (gST->ConIn, &Key))) {
-    //
-    // just throw away Key
-    //
-  }
-}
-
-// Configuration
-#define GLYPH_WIDTH         8
-#define GLYPH_HEIGHT        19
-#define PADDING_X           (2 * GLYPH_WIDTH) // 2 chars padding (unscaled)
-#define PADDING_Y           (1 * GLYPH_HEIGHT) // 1 line padding (unscaled)
-#define BORDER_WIDTH        4
-
-// Colors (Blue Background, White Text, White Border)
-#define POPUP_BG_COLOR      {   4,  117,  204, 0xFF}
-#define POPUP_TEXT_COLOR    {0xFF, 0xFF, 0xFF, 0xFF}
-#define POPUP_BORDER_COLOR  {0xFF, 0xFF, 0xFF, 0xFF}
-
-/**
-  Helper: Upscales a source Blt buffer by ScaleFactor into a destination buffer.
-  Uses Nearest-Neighbor scaling.
-**/
-STATIC
-VOID
-UpscaleBuffer (
-  IN EFI_GRAPHICS_OUTPUT_BLT_PIXEL *Source,
-  IN UINTN                          SourceWidth,
-  IN UINTN                          SourceHeight,
-  IN UINTN                          ScaleFactor,
-  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL *Dest
-  )
-{
-  UINTN x, y, i, j;
-  UINTN DestWidth = SourceWidth * ScaleFactor;
-
-  for (y = 0; y < SourceHeight; y++) {
-    for (x = 0; x < SourceWidth; x++) {
-      EFI_GRAPHICS_OUTPUT_BLT_PIXEL Pixel = Source[y * SourceWidth + x];
-
-      // Top-left corner of the destination block
-      UINTN DestStartX = x * ScaleFactor;
-      UINTN DestStartY = y * ScaleFactor;
-
-      // Fill the ScaleFactor * ScaleFactor block in the destination
-      for (i = 0; i < ScaleFactor; i++) {       // Row
-        for (j = 0; j < ScaleFactor; j++) {     // Column
-          Dest[(DestStartY + i) * DestWidth + (DestStartX + j)] = Pixel;
-        }
-      }
-    }
-  }
-}
-
-/**
-  Clears the screen to black using GOP.
-**/
-VOID
-EFIAPI
-ClearScreen (
-  VOID
-  )
-{
-  EFI_STATUS                    Status;
-  EFI_GRAPHICS_OUTPUT_PROTOCOL  *Gop;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL Black = {0x00, 0x00, 0x00, 0x00};
-
-  // Locate GOP
-  Status = gBS->LocateProtocol(&gEfiGraphicsOutputProtocolGuid, NULL, (VOID **)&Gop);
-  if (EFI_ERROR(Status)) {
-    return;
-  }
-
-  // Fill the entire screen with black
-  Gop->Blt (
-    Gop,
-    &Black,
-    EfiBltVideoFill,
-    0, 0, // Source X, Y (Not used for Fill)
-    0, 0, // Dest X, Y
-    Gop->Mode->Info->HorizontalResolution,
-    Gop->Mode->Info->VerticalResolution,
-    0     // Delta (Not used for Fill)
-  );
-}
-
-/**
-  Draw a pop up windows based on the dimension, number of lines and
-  strings specified. (GOP Scaled Version)
-
-  @param RequestedWidth  The width of the pop-up in standard character cells.
-                         If 0, autosize to fit longest string.
-  @param NumberOfLines   The number of lines.
-  @param ...             A series of text strings that displayed in the pop-up.
-
-**/
-VOID
-EFIAPI
-CreateMultiStringPopUpScaled (
-  IN  UINTN  ScaleFactor,
-  IN  UINTN  RequestedWidth,
-  IN  UINTN  NumberOfLines,
-  ...
-  )
-{
-  EFI_STATUS                     Status;
-  VA_LIST                        Args, ArgsCopy;
-  CHAR16                         *String;
-  UINTN                          Index;
-
-  // Protocols
-  EFI_GRAPHICS_OUTPUT_PROTOCOL   *Gop;
-  EFI_HII_FONT_PROTOCOL          *HiiFont;
-
-  // Dimensions (Pixels)
-  UINTN                          ScreenWidth, ScreenHeight;
-  UINTN                          UnscaledContentW, UnscaledContentH;
-  UINTN                          BoxW, BoxH;
-  UINTN                          BoxX, BoxY;
-
-  // Buffers
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *BackBuffer = NULL;      // Saves what is behind popup
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *RenderBuffer1x = NULL;  // Temporary buffer for font rendering
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *RenderBufferScaled = NULL;  // Upscaled buffer for display
-  EFI_IMAGE_OUTPUT               *BltBufferObj = NULL;    // HII wrapper
-
-  // 1. Locate Protocols
-  Status = gBS->LocateProtocol(&gEfiGraphicsOutputProtocolGuid, NULL, (VOID **)&Gop);
-  if (EFI_ERROR(Status)) return;
-
-  Status = gBS->LocateProtocol(&gEfiHiiFontProtocolGuid, NULL, (VOID **)&HiiFont);
-  if (EFI_ERROR(Status)) return;
-
-  ScreenWidth  = Gop->Mode->Info->HorizontalResolution;
-  ScreenHeight = Gop->Mode->Info->VerticalResolution;
-
-  // 2. Calculate Dimensions
-  // If RequestedWidth is 0, we must measure the strings.
-  // If provided, RequestedWidth is usually in "Columns" (chars).
-
-  UINTN MaxStrLen = 0;
-
-  VA_START(Args, NumberOfLines);
-  VA_COPY(ArgsCopy, Args);
-  for (Index = 0; Index < NumberOfLines; Index++) {
-    String = VA_ARG(Args, CHAR16 *);
-    if (String != NULL) {
-      UINTN Len = StrLen(String);
-      if (Len > MaxStrLen) MaxStrLen = Len;
-    }
-  }
-  VA_END(Args);
-
-  if (RequestedWidth == 0) {
-    RequestedWidth = MaxStrLen;
-  }
-
-  // Enforce a minimum width if needed, or cap to screen width logic
-  if (RequestedWidth < MaxStrLen) RequestedWidth = MaxStrLen;
-
-  // Calculate pixel dimensions based on 8x19 standard glyphs
-  UnscaledContentW = RequestedWidth * GLYPH_WIDTH;
-  UnscaledContentH = NumberOfLines * GLYPH_HEIGHT;
-
-  // Final Box Size (Scaled Content + Scaled Padding)
-  // We apply scale factor to everything to ensure crisp look
-  BoxW = (UnscaledContentW * ScaleFactor) + (PADDING_X * ScaleFactor * 2);
-  BoxH = (UnscaledContentH * ScaleFactor) + (PADDING_Y * ScaleFactor * 2);
-
-  // Center on screen
-  BoxX = (ScreenWidth > BoxW) ? (ScreenWidth - BoxW) / 2 : 0;
-  BoxY = (ScreenHeight > BoxH) ? (ScreenHeight - BoxH) / 2 : 0;
-
-  // 3. Save Background
-  BackBuffer = AllocateZeroPool(BoxW * BoxH * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
-  if (BackBuffer != NULL) {
-    Gop->Blt(Gop, BackBuffer, EfiBltVideoToBltBuffer, BoxX, BoxY, 0, 0, BoxW, BoxH, 0);
-  }
-
-  // 4. Draw Box & Border
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL BgColor = POPUP_BG_COLOR;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL BorderColor = POPUP_BORDER_COLOR;
-
-  // Solid Fill
-  Gop->Blt(Gop, &BgColor, EfiBltVideoFill, 0, 0, BoxX, BoxY, BoxW, BoxH, 0);
-
-  // Borders
-  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX, BoxY, BoxW, BORDER_WIDTH, 0); // Top
-  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX, BoxY + BoxH - BORDER_WIDTH, BoxW, BORDER_WIDTH, 0); // Bottom
-  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX, BoxY, BORDER_WIDTH, BoxH, 0); // Left
-  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX + BoxW - BORDER_WIDTH, BoxY, BORDER_WIDTH, BoxH, 0); // Right
-
-  // 5. Prepare for Text Rendering
-  // We allocate enough space for one line at a time
-  UINTN LinePixels1x = UnscaledContentW * GLYPH_HEIGHT;
-  RenderBuffer1x = AllocateZeroPool(LinePixels1x * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
-  RenderBufferScaled = AllocateZeroPool(LinePixels1x * ScaleFactor * ScaleFactor * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
-
-  BltBufferObj = AllocateZeroPool(sizeof(EFI_IMAGE_OUTPUT));
-  BltBufferObj->Width = (UINT16)UnscaledContentW;
-  BltBufferObj->Height = (UINT16)GLYPH_HEIGHT;
-  BltBufferObj->Image.Bitmap = RenderBuffer1x;
-
-  EFI_FONT_DISPLAY_INFO FontInfo;
-  ZeroMem(&FontInfo, sizeof(EFI_FONT_DISPLAY_INFO));
-  FontInfo.ForegroundColor = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)POPUP_TEXT_COLOR;
-  FontInfo.BackgroundColor = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)POPUP_BG_COLOR;
-
-  // 6. Render Text Loop
-  UINTN CurrentY = BoxY + (PADDING_Y * ScaleFactor);
-  UINTN TextStartX = BoxX + (PADDING_X * ScaleFactor);
-
-  for (Index = 0; Index < NumberOfLines; Index++) {
-    String = VA_ARG(ArgsCopy, CHAR16 *);
-
-    if (String != NULL) {
-      // A. Clear 1x buffer with BG color (clean slate)
-      SetMem32(RenderBuffer1x, LinePixels1x * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL), *(UINT32*)&BgColor);
-
-      // B. Calculate Centering Offset WITHIN the buffer
-      //    We do the math in 1x pixels
-      UINTN StrPxW = StrLen(String) * GLYPH_WIDTH;
-      UINTN InternalOffsetX = 0;
-
-      if (StrPxW < UnscaledContentW) {
-        InternalOffsetX = (UnscaledContentW - StrPxW) / 2;
-      }
-
-      // C. Render Text into the buffer at the calculated offset
-      HiiFont->StringToImage (
-          HiiFont,
-          EFI_HII_OUT_FLAG_CLIP,              // Standard flag
-          String,
-          &FontInfo,
-          &BltBufferObj,
-          InternalOffsetX,                    // X Offset inside the buffer
-          0,                                  // Y Offset (Top of line)
-          NULL, NULL, NULL
-      );
-
-      // D. Scale up
-      UpscaleBuffer(RenderBuffer1x, UnscaledContentW, GLYPH_HEIGHT, ScaleFactor, RenderBufferScaled);
-
-      // E. Blt to Screen at FIXED Left Margin
-      //    We now blit the entire "strip" which fits perfectly inside the box padding
-      Gop->Blt(Gop, RenderBufferScaled, EfiBltBufferToVideo,
-               0, 0,
-               TextStartX, CurrentY,          // Fixed X Position
-               UnscaledContentW * ScaleFactor, GLYPH_HEIGHT * ScaleFactor,
-               UnscaledContentW * ScaleFactor * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
-    }
-
-    CurrentY += (GLYPH_HEIGHT * ScaleFactor);
-  }
-  VA_END(ArgsCopy);
-
-  if (RenderBuffer1x) FreePool(RenderBuffer1x);
-  if (RenderBufferScaled) FreePool(RenderBufferScaled);
-  if (BltBufferObj)   FreePool(BltBufferObj);
-}
-
-STATIC
-VOID
 HexDump (
   IN UINT8 *InputData,
   IN UINTN InputLen,
@@ -1150,41 +876,6 @@ HexDump (
     OutputStr[i * 2 + 1] = HexMap[InputData[i] & 0x0F];
   }
   OutputStr[InputLen * 2] = '\0';
-}
-
-STATIC
-UINTN
-GetDisplayScaleFactor (
-  VOID
-  )
-{
-EFI_STATUS                             Status;
-  EFI_GRAPHICS_OUTPUT_PROTOCOL         *Gop;
-  UINT32                               ModeIndex;
-  UINT32                               MaxHRes = 0;
-  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *Info;
-  UINTN                                SizeOfInfo;
-
-  Status = gBS->LocateProtocol (&gEfiGraphicsOutputProtocolGuid, NULL, (VOID **)&Gop);
-  if (EFI_ERROR (Status) || Gop == NULL)
-    return 1;
-
-  // Iterate through all modes to find the largest (presumed native) resolution
-  for (ModeIndex = 0; ModeIndex < Gop->Mode->MaxMode; ModeIndex++) {
-    Status = Gop->QueryMode (Gop, ModeIndex, &SizeOfInfo, &Info);
-
-    if (!EFI_ERROR (Status)) {
-      if (Info->HorizontalResolution > MaxHRes) {
-        MaxHRes = Info->HorizontalResolution;
-      }
-      FreePool (Info);
-    }
-  }
-
-  if (MaxHRes > 1920)
-    return 2;
-
-  return 1;
 }
 
 STATIC
@@ -1219,9 +910,8 @@ ShowBtgErrorPopup (
   Events[0] = gST->ConIn->WaitForKey;
 
   do {
-    ClearScreen();
-    CreateMultiStringPopUpScaled (
-        GetDisplayScaleFactor(),
+    DrawGraphicPopUp (
+        ErrorPopUp,
         96,
         13,
         L"Firmware Update Skipped",

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -34,11 +34,11 @@
   BaseCryptLib
   BlParseLib
   CbfsLib
-  CustomizedDisplayLib
   DebugLib
   EfiVarsLib
   FmapLib
   MemoryAllocationLib
+  PopUpLib
   PrintLib
   SmmStoreLib
   UefiBootServicesTableLib
@@ -53,9 +53,7 @@
   MdePkg/MdePkg.dec
 
 [Protocols]
-  gEfiGraphicsOutputProtocolGuid  ## CONSUMES
   gEfiSmbiosProtocolGuid          ## CONSUMES
-  gEfiHiiFontProtocolGuid         ## CONSUMES
 
 [Guids]
   gDasharoSystemFeaturesGuid

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
@@ -1,12 +1,21 @@
 //
 // A utility library for drawing simple popups.
 //
+// Functions for constructing a popup dynamically and then displaying it in both
+// text and GUI formats.
+//
 // Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
 // SPDX-License-Identifier: GPL-2-or-later
 //
 
 #include <Library/PopUpLib.h>
 
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/CustomizedDisplayLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
 VOID
@@ -25,4 +34,205 @@ DrainInput (
     // Throw away the key.
     //
   }
+}
+
+VOID
+EFIAPI
+PopUpInit (
+  OUT PopUpData  *PopUp,
+  IN UINTN       Width
+  )
+{
+  ZeroMem (PopUp, sizeof(*PopUp));
+  PopUp->Width = Width;
+}
+
+VOID
+EFIAPI
+AddTitle (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line
+  )
+{
+  CHAR16  *Separator;
+  UINTN   Index;
+
+  AddLineF (PopUp, L"%s", Line);
+
+  Separator = AllocatePool (StrSize (Line));
+  if (Separator == NULL) {
+    return;
+  }
+
+  for (Index = 0; Line[Index] != L'\0'; ++Index) {
+    Separator[Index] = BOXDRAW_DOUBLE_HORIZONTAL;
+  }
+  Separator[Index] = L'\0';
+
+  AddLine (PopUp, Separator);
+  AddLine (PopUp, L"");
+
+  FreePool (Separator);
+}
+
+STATIC
+VOID
+AddALine (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line,
+  IN BOOLEAN       FullWidth
+  )
+{
+  UINTN   ByteLength;
+  UINTN   Index;
+  CHAR16  *Buffer;
+
+  // Cut the bottom lines off if we're out of space.
+  if (PopUp->Length == ARRAY_SIZE (PopUp->Lines)) {
+    FreePool (PopUp->Lines[PopUp->Length - 1]);
+    FreePool (PopUp->Lines[PopUp->Length - 2]);
+    PopUp->Length -= 2;
+
+    AddALine (PopUp, L"...", /*FullWidth=*/FALSE);
+  }
+
+  ByteLength = FullWidth ? (PopUp->Width + 1) * 2 : StrSize (Line);
+
+  Buffer = AllocatePool (ByteLength);
+  if (Buffer == NULL) {
+    return;
+  }
+
+  StrCpyS (Buffer, ByteLength / 2, Line);
+
+  if (FullWidth) {
+    // `- 1` because otherwise the first character gets lost.  Off-by-one error?
+    for (Index = StrLen (Buffer); Index < PopUp->Width - 1; ++Index) {
+      Buffer[Index] = L' ';
+    }
+    Buffer[Index] = L'\0';
+  }
+
+  PopUp->Lines[PopUp->Length++] = Buffer;
+}
+
+STATIC
+VOID
+EFIAPI
+AddFLine (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Format,
+  IN VA_LIST       Marker,
+  IN BOOLEAN       FullWidth
+  )
+{
+  VA_LIST  ExtraMarker;
+  UINTN    ByteLength;
+  CHAR16   *Buffer;
+
+  VA_COPY (ExtraMarker, Marker);
+  ByteLength = (SPrintLength (Format, ExtraMarker) + 1) * 2;
+  VA_END (ExtraMarker);
+
+  Buffer = AllocatePool (ByteLength);
+  if (Buffer == NULL) {
+    return;
+  }
+
+  UnicodeVSPrint (Buffer, ByteLength, Format, Marker);
+
+  AddALine (PopUp, Buffer, FullWidth);
+  FreePool (Buffer);
+}
+
+VOID
+EFIAPI
+AddLineF (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Format,
+  ...
+  )
+{
+  VA_LIST  Marker;
+
+  VA_START (Marker, Format);
+  AddFLine (PopUp, Format, Marker, /*FullWidth=*/FALSE);
+  VA_END (Marker);
+}
+
+VOID
+EFIAPI
+AddFullLineF (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Format,
+  ...
+  )
+{
+  VA_LIST  Marker;
+
+  VA_START (Marker, Format);
+  AddFLine (PopUp, Format, Marker, /*FullWidth=*/TRUE);
+  VA_END (Marker);
+}
+
+VOID
+EFIAPI
+AddLine (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line
+  )
+{
+  AddALine (PopUp, Line, /*FullWidth=*/FALSE);
+}
+
+VOID
+EFIAPI
+AddFullLine (
+  IN PopUpData     *PopUp,
+  IN CONST CHAR16  *Line
+  )
+{
+  AddALine (PopUp, Line, /*FullWidth=*/TRUE);
+}
+
+VOID
+EFIAPI
+PopUpDraw (
+  IN CONST PopUpData  *PopUp,
+  IN PopupKind        GuiKind
+  )
+{
+  //
+  // A "dynamic" popup.  Always passing all lines, but limiting number of lines
+  // that get displayed, the implementation doesn't look at the rest of lines.
+  //
+  CreateMultiStringPopUp (
+      PopUp->Width,
+      PopUp->Length,
+      PopUp->Lines[0], PopUp->Lines[1], PopUp->Lines[2], PopUp->Lines[3],
+      PopUp->Lines[4], PopUp->Lines[5], PopUp->Lines[6], PopUp->Lines[7],
+      PopUp->Lines[8], PopUp->Lines[9], PopUp->Lines[10], PopUp->Lines[11],
+      PopUp->Lines[12], PopUp->Lines[13], PopUp->Lines[14], PopUp->Lines[15],
+      PopUp->Lines[16], PopUp->Lines[17], PopUp->Lines[18], PopUp->Lines[19],
+      PopUp->Lines[20], PopUp->Lines[21], PopUp->Lines[22], PopUp->Lines[23]
+      );
+
+  //
+  // Using the same approach for GUI.  This is a no-op if graphics isn't
+  // available, so must be done after drawing text version.  Otherwise, it
+  // clears the screen and draws a nicer version.  This way in the absence of
+  // GOP the text is displayed (at least on serial) and with the GOP serial gets
+  // text version while display has a GUI one.
+  //
+  DrawGraphicPopUp (
+      GuiKind,
+      PopUp->Width,
+      PopUp->Length,
+      PopUp->Lines[0], PopUp->Lines[1], PopUp->Lines[2], PopUp->Lines[3],
+      PopUp->Lines[4], PopUp->Lines[5], PopUp->Lines[6], PopUp->Lines[7],
+      PopUp->Lines[8], PopUp->Lines[9], PopUp->Lines[10], PopUp->Lines[11],
+      PopUp->Lines[12], PopUp->Lines[13], PopUp->Lines[14], PopUp->Lines[15],
+      PopUp->Lines[16], PopUp->Lines[17], PopUp->Lines[18], PopUp->Lines[19],
+      PopUp->Lines[20], PopUp->Lines[21], PopUp->Lines[22], PopUp->Lines[23]
+      );
 }

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
@@ -1,0 +1,28 @@
+//
+// A utility library for drawing simple popups.
+//
+// Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+// SPDX-License-Identifier: GPL-2-or-later
+//
+
+#include <Library/PopUpLib.h>
+
+#include <Library/UefiBootServicesTableLib.h>
+
+VOID
+EFIAPI
+DrainInput (
+  VOID
+)
+{
+  EFI_INPUT_KEY  Key;
+
+  //
+  // Drain any queued keys.
+  //
+  while (!EFI_ERROR (gST->ConIn->ReadKeyStroke (gST->ConIn, &Key))) {
+    //
+    // Throw away the key.
+    //
+  }
+}

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpGui.c
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpGui.c
@@ -1,0 +1,313 @@
+//
+// A utility library for drawing simple popups.
+//
+// Implementation of drawing a GUI popup that takes DPI into account to a
+// degree.
+//
+// Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+// SPDX-License-Identifier: GPL-2-or-later
+//
+
+#include <Library/PopUpLib.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+/* #include <PiDxe.h> */
+#include <Protocol/GraphicsOutput.h>
+#include <Protocol/HiiFont.h>
+
+// Configuration
+#define GLYPH_WIDTH         8
+#define GLYPH_HEIGHT        19
+#define PADDING_X           (2 * GLYPH_WIDTH) // 2 chars padding (unscaled)
+#define PADDING_Y           (1 * GLYPH_HEIGHT) // 1 line padding (unscaled)
+#define BORDER_WIDTH        4
+
+// Colors (Blue Background, White Text, White Border)
+#define POPUP_TEXT_COLOR    {0xFF, 0xFF, 0xFF, 0xFF}
+#define POPUP_BORDER_COLOR  {0xFF, 0xFF, 0xFF, 0xFF}
+
+STATIC EFI_GRAPHICS_OUTPUT_BLT_PIXEL ErrorBgColor   = { 4, 117, 204, 0xFF };
+STATIC EFI_GRAPHICS_OUTPUT_BLT_PIXEL SuccessBgColor = { 3, 176, 100, 0xFF };
+
+/**
+  Helper: Upscales a source Blt buffer by ScaleFactor into a destination buffer.
+  Uses Nearest-Neighbor scaling.
+**/
+STATIC
+VOID
+UpscaleBuffer (
+  IN EFI_GRAPHICS_OUTPUT_BLT_PIXEL *Source,
+  IN UINTN                          SourceWidth,
+  IN UINTN                          SourceHeight,
+  IN UINTN                          ScaleFactor,
+  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL *Dest
+  )
+{
+  UINTN x, y, i, j;
+  UINTN DestWidth = SourceWidth * ScaleFactor;
+
+  for (y = 0; y < SourceHeight; y++) {
+    for (x = 0; x < SourceWidth; x++) {
+      EFI_GRAPHICS_OUTPUT_BLT_PIXEL Pixel = Source[y * SourceWidth + x];
+
+      // Top-left corner of the destination block
+      UINTN DestStartX = x * ScaleFactor;
+      UINTN DestStartY = y * ScaleFactor;
+
+      // Fill the ScaleFactor * ScaleFactor block in the destination
+      for (i = 0; i < ScaleFactor; i++) {       // Row
+        for (j = 0; j < ScaleFactor; j++) {     // Column
+          Dest[(DestStartY + i) * DestWidth + (DestStartX + j)] = Pixel;
+        }
+      }
+    }
+  }
+}
+
+/**
+  Clears the screen to black using GOP.
+**/
+STATIC
+VOID
+EFIAPI
+ClearScreen (
+  VOID
+  )
+{
+  EFI_STATUS                    Status;
+  EFI_GRAPHICS_OUTPUT_PROTOCOL  *Gop;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL Black = {0x00, 0x00, 0x00, 0x00};
+
+  // Locate GOP
+  Status = gBS->LocateProtocol(&gEfiGraphicsOutputProtocolGuid, NULL, (VOID **)&Gop);
+  if (EFI_ERROR(Status)) {
+    return;
+  }
+
+  // Fill the entire screen with black
+  Gop->Blt (
+    Gop,
+    &Black,
+    EfiBltVideoFill,
+    0, 0, // Source X, Y (Not used for Fill)
+    0, 0, // Dest X, Y
+    Gop->Mode->Info->HorizontalResolution,
+    Gop->Mode->Info->VerticalResolution,
+    0     // Delta (Not used for Fill)
+  );
+}
+
+STATIC
+UINTN
+GetDisplayScaleFactor (
+  IN EFI_GRAPHICS_OUTPUT_PROTOCOL  *Gop
+  )
+{
+  EFI_STATUS                           Status;
+  UINT32                               ModeIndex;
+  UINT32                               MaxHRes = 0;
+  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *Info;
+  UINTN                                SizeOfInfo;
+
+  // Iterate through all modes to find the largest (presumed native) resolution
+  for (ModeIndex = 0; ModeIndex < Gop->Mode->MaxMode; ModeIndex++) {
+    Status = Gop->QueryMode (Gop, ModeIndex, &SizeOfInfo, &Info);
+
+    if (!EFI_ERROR (Status)) {
+      if (Info->HorizontalResolution > MaxHRes) {
+        MaxHRes = Info->HorizontalResolution;
+      }
+      FreePool (Info);
+    }
+  }
+
+  if (MaxHRes > 1920)
+    return 2;
+
+  return 1;
+}
+
+/**
+  Draw a pop up windows based on the dimension, number of lines and
+  strings specified. (GOP Scaled Version)
+
+  @param BgColor         Color of the background.
+  @param RequestedWidth  The width of the pop-up in standard character cells.
+                         If 0, autosize to fit longest string.
+  @param NumberOfLines   The number of lines.
+  @param ...             A series of text strings that displayed in the pop-up.
+
+**/
+VOID
+EFIAPI
+DrawGraphicPopUp (
+  IN  PopupKind  Kind,
+  IN  UINTN      RequestedWidth,
+  IN  UINTN      NumberOfLines,
+  ...
+  )
+{
+  UINTN       ScaleFactor;
+  EFI_STATUS  Status;
+  VA_LIST     Args, ArgsCopy;
+  CHAR16      *String;
+  UINTN       Index;
+
+  // Protocols
+  EFI_GRAPHICS_OUTPUT_PROTOCOL   *Gop;
+  EFI_HII_FONT_PROTOCOL          *HiiFont;
+
+  // Dimensions (Pixels)
+  UINTN                          ScreenWidth, ScreenHeight;
+  UINTN                          UnscaledContentW, UnscaledContentH;
+  UINTN                          BoxW, BoxH;
+  UINTN                          BoxX, BoxY;
+
+  // Buffers
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *BackBuffer = NULL;      // Saves what is behind popup
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *RenderBuffer1x = NULL;  // Temporary buffer for font rendering
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *RenderBufferScaled = NULL;  // Upscaled buffer for display
+  EFI_IMAGE_OUTPUT               *BltBufferObj = NULL;    // HII wrapper
+
+  // 1. Locate Protocols
+  Status = gBS->LocateProtocol(&gEfiGraphicsOutputProtocolGuid, NULL, (VOID **)&Gop);
+  if (EFI_ERROR(Status)) return;
+
+  Status = gBS->LocateProtocol(&gEfiHiiFontProtocolGuid, NULL, (VOID **)&HiiFont);
+  if (EFI_ERROR(Status)) return;
+
+  ScreenWidth  = Gop->Mode->Info->HorizontalResolution;
+  ScreenHeight = Gop->Mode->Info->VerticalResolution;
+
+  // 2. Calculate Dimensions
+  // If RequestedWidth is 0, we must measure the strings.
+  // If provided, RequestedWidth is usually in "Columns" (chars).
+
+  UINTN MaxStrLen = 0;
+
+  VA_START(Args, NumberOfLines);
+  VA_COPY(ArgsCopy, Args);
+  for (Index = 0; Index < NumberOfLines; Index++) {
+    String = VA_ARG(Args, CHAR16 *);
+    if (String != NULL) {
+      UINTN Len = StrLen(String);
+      if (Len > MaxStrLen) MaxStrLen = Len;
+    }
+  }
+  VA_END(Args);
+
+  if (RequestedWidth == 0) {
+    RequestedWidth = MaxStrLen;
+  }
+
+  ClearScreen ();
+
+  // Enforce a minimum width if needed, or cap to screen width logic
+  if (RequestedWidth < MaxStrLen) RequestedWidth = MaxStrLen;
+
+  // Calculate pixel dimensions based on 8x19 standard glyphs
+  UnscaledContentW = RequestedWidth * GLYPH_WIDTH;
+  UnscaledContentH = NumberOfLines * GLYPH_HEIGHT;
+
+  // Final Box Size (Scaled Content + Scaled Padding)
+  // We apply scale factor to everything to ensure crisp look
+  ScaleFactor = GetDisplayScaleFactor (Gop);
+  BoxW = (UnscaledContentW * ScaleFactor) + (PADDING_X * ScaleFactor * 2);
+  BoxH = (UnscaledContentH * ScaleFactor) + (PADDING_Y * ScaleFactor * 2);
+
+  // Center on screen
+  BoxX = (ScreenWidth > BoxW) ? (ScreenWidth - BoxW) / 2 : 0;
+  BoxY = (ScreenHeight > BoxH) ? (ScreenHeight - BoxH) / 2 : 0;
+
+  // 3. Save Background
+  BackBuffer = AllocateZeroPool(BoxW * BoxH * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
+  if (BackBuffer != NULL) {
+    Gop->Blt(Gop, BackBuffer, EfiBltVideoToBltBuffer, BoxX, BoxY, 0, 0, BoxW, BoxH, 0);
+  }
+
+  // 4. Draw Box & Border
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL BorderColor = POPUP_BORDER_COLOR;
+
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL BgColor = (Kind == SuccessPopUp ? SuccessBgColor : ErrorBgColor);
+
+  // Solid Fill
+  Gop->Blt(Gop, &BgColor, EfiBltVideoFill, 0, 0, BoxX, BoxY, BoxW, BoxH, 0);
+
+  // Borders
+  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX, BoxY, BoxW, BORDER_WIDTH, 0); // Top
+  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX, BoxY + BoxH - BORDER_WIDTH, BoxW, BORDER_WIDTH, 0); // Bottom
+  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX, BoxY, BORDER_WIDTH, BoxH, 0); // Left
+  Gop->Blt(Gop, &BorderColor, EfiBltVideoFill, 0, 0, BoxX + BoxW - BORDER_WIDTH, BoxY, BORDER_WIDTH, BoxH, 0); // Right
+
+  // 5. Prepare for Text Rendering
+  // We allocate enough space for one line at a time
+  UINTN LinePixels1x = UnscaledContentW * GLYPH_HEIGHT;
+  RenderBuffer1x = AllocateZeroPool(LinePixels1x * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
+  RenderBufferScaled = AllocateZeroPool(LinePixels1x * ScaleFactor * ScaleFactor * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
+
+  BltBufferObj = AllocateZeroPool(sizeof(EFI_IMAGE_OUTPUT));
+  BltBufferObj->Width = (UINT16)UnscaledContentW;
+  BltBufferObj->Height = (UINT16)GLYPH_HEIGHT;
+  BltBufferObj->Image.Bitmap = RenderBuffer1x;
+
+  EFI_FONT_DISPLAY_INFO FontInfo;
+  ZeroMem(&FontInfo, sizeof(EFI_FONT_DISPLAY_INFO));
+  FontInfo.ForegroundColor = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)POPUP_TEXT_COLOR;
+  FontInfo.BackgroundColor = BgColor;
+
+  // 6. Render Text Loop
+  UINTN CurrentY = BoxY + (PADDING_Y * ScaleFactor);
+  UINTN TextStartX = BoxX + (PADDING_X * ScaleFactor);
+
+  for (Index = 0; Index < NumberOfLines; Index++) {
+    String = VA_ARG(ArgsCopy, CHAR16 *);
+
+    if (String != NULL) {
+      // A. Clear 1x buffer with BG color (clean slate)
+      SetMem32(RenderBuffer1x, LinePixels1x * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL), *(UINT32 *)&BgColor);
+
+      // B. Calculate Centering Offset WITHIN the buffer
+      //    We do the math in 1x pixels
+      UINTN StrPxW = StrLen(String) * GLYPH_WIDTH;
+      UINTN InternalOffsetX = 0;
+
+      if (StrPxW < UnscaledContentW) {
+        InternalOffsetX = (UnscaledContentW - StrPxW) / 2;
+      }
+
+      // C. Render Text into the buffer at the calculated offset
+      HiiFont->StringToImage (
+          HiiFont,
+          EFI_HII_OUT_FLAG_CLIP,              // Standard flag
+          String,
+          &FontInfo,
+          &BltBufferObj,
+          InternalOffsetX,                    // X Offset inside the buffer
+          0,                                  // Y Offset (Top of line)
+          NULL, NULL, NULL
+      );
+
+      // D. Scale up
+      UpscaleBuffer(RenderBuffer1x, UnscaledContentW, GLYPH_HEIGHT, ScaleFactor, RenderBufferScaled);
+
+      // E. Blt to Screen at FIXED Left Margin
+      //    We now blit the entire "strip" which fits perfectly inside the box padding
+      Gop->Blt(Gop, RenderBufferScaled, EfiBltBufferToVideo,
+               0, 0,
+               TextStartX, CurrentY,          // Fixed X Position
+               UnscaledContentW * ScaleFactor, GLYPH_HEIGHT * ScaleFactor,
+               UnscaledContentW * ScaleFactor * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
+    }
+
+    CurrentY += (GLYPH_HEIGHT * ScaleFactor);
+  }
+  VA_END(ArgsCopy);
+
+  if (RenderBuffer1x) FreePool(RenderBuffer1x);
+  if (RenderBufferScaled) FreePool(RenderBufferScaled);
+  if (BltBufferObj)   FreePool(BltBufferObj);
+}

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpLib.inf
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpLib.inf
@@ -1,0 +1,34 @@
+## @file
+#  A utility library for drawing simple popups.
+#
+#  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#  SPDX-License-Identifier: GPL-2-or-later
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PopUpLib
+  FILE_GUID                      = E8222229-BF8F-40E0-B4A5-EBB4031A8A97
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PopUpLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  PopUpCore.c
+  PopUpGui.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  BaseMemoryLib

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -915,6 +915,34 @@ GetFmpImageInfoDescriptorVer (
 }
 
 /**
+  Gets pointer to the image data from payload's header.
+
+  @param[in]  ImageHeader   The payload image header.
+
+  @return The pointer to the start of the image data.
+**/
+VOID *
+GetFmpImage (
+  IN EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *ImageHeader
+  )
+{
+  if (ImageHeader->Version >= EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER_INIT_VERSION) {
+    return (UINT8 *)(ImageHeader + 1);
+  }
+
+  //
+  // If the EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER is version 1,
+  // Header should exclude UpdateHardwareInstance field, and
+  // ImageCapsuleSupport field if version is 2.
+  //
+  if (ImageHeader->Version == 1) {
+    return (UINT8 *)ImageHeader + OFFSET_OF (EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER, UpdateHardwareInstance);
+  }
+
+  return (UINT8 *)ImageHeader + OFFSET_OF (EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER, ImageCapsuleSupport);
+}
+
+/**
   Set FMP image data.
 
   @param[in]  Handle        A FMP handle.
@@ -959,20 +987,7 @@ SetFmpImageData (
     mFmpProgress = NULL;
   }
 
-  if (ImageHeader->Version >= EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER_INIT_VERSION) {
-    Image = (UINT8 *)(ImageHeader + 1);
-  } else {
-    //
-    // If the EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER is version 1,
-    // Header should exclude UpdateHardwareInstance field, and
-    // ImageCapsuleSupport field if version is 2.
-    //
-    if (ImageHeader->Version == 1) {
-      Image = (UINT8 *)ImageHeader + OFFSET_OF (EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER, UpdateHardwareInstance);
-    } else {
-      Image = (UINT8 *)ImageHeader + OFFSET_OF (EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER, ImageCapsuleSupport);
-    }
-  }
+  Image = GetFmpImage (ImageHeader);
 
   if (ImageHeader->UpdateVendorCodeSize == 0) {
     VendorCode = NULL;

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -42,6 +42,8 @@
 #include <Protocol/FirmwareManagementProgress.h>
 #include <Protocol/DevicePath.h>
 
+#include "UpdateReport.h"
+
 EFI_SYSTEM_RESOURCE_TABLE  *mEsrtTable = NULL;
 
 BOOLEAN    mDxeCapsuleLibEndOfDxe      = FALSE;
@@ -1190,9 +1192,10 @@ RecordFmpCapsuleStatus (
 
   This function need support nested FMP capsule.
 
-  @param[in]  CapsuleHeader         Points to a capsule header.
-  @param[in]  CapFileName           Capsule file name.
-  @param[out] ResetRequired         Indicates whether reset is required or not.
+  @param[in]     CapsuleHeader      Points to a capsule header.
+  @param[in]     CapFileName        Capsule file name.
+  @param[out]    ResetRequired      Indicates whether reset is required or not.
+  @param[in,out] CapsuleResult      Outcome of processing the capsule.
 
   @retval EFI_SUCESS            Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
@@ -1200,11 +1203,13 @@ RecordFmpCapsuleStatus (
   @retval EFI_OUT_OF_RESOURCES  Not enough memory.
   @retval EFI_NOT_READY         No FMP protocol to handle this FMP capsule.
 **/
+STATIC
 EFI_STATUS
 ProcessFmpCapsuleImage (
   IN EFI_CAPSULE_HEADER  *CapsuleHeader,
   IN CHAR16              *CapFileName   OPTIONAL,
-  OUT BOOLEAN            *ResetRequired OPTIONAL
+  OUT BOOLEAN            *ResetRequired OPTIONAL,
+  IN OUT CapsuleResult   *CapsuleResult OPTIONAL
   )
 {
   EFI_STATUS                                    Status;
@@ -1221,9 +1226,10 @@ ProcessFmpCapsuleImage (
   UINTN                                         Index2;
   BOOLEAN                                       NotReady;
   BOOLEAN                                       Abort;
+  BOOLEAN                                       PayloadAborted;
 
   if (!IsFmpCapsuleGuid (&CapsuleHeader->CapsuleGuid)) {
-    return ProcessFmpCapsuleImage ((EFI_CAPSULE_HEADER *)((UINTN)CapsuleHeader + CapsuleHeader->HeaderSize), CapFileName, ResetRequired);
+    return ProcessFmpCapsuleImage ((EFI_CAPSULE_HEADER *)((UINTN)CapsuleHeader + CapsuleHeader->HeaderSize), CapFileName, ResetRequired, CapsuleResult);
   }
 
   NotReady = FALSE;
@@ -1269,6 +1275,7 @@ ProcessFmpCapsuleImage (
                );
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "Driver Return Status = %r\n", Status));
+      ReportCapsuleOutcome (CapsuleResult, CAPSULE_DRIVER, Status);
       return Status;
     }
   }
@@ -1317,6 +1324,7 @@ ProcessFmpCapsuleImage (
       continue;
     }
 
+    PayloadAborted = FALSE;
     for (Index2 = 0; Index2 < NumberOfHandles; Index2++) {
       if (Abort) {
         RecordFmpCapsuleStatus (
@@ -1337,6 +1345,7 @@ ProcessFmpCapsuleImage (
                  );
       if (Status != EFI_SUCCESS) {
         Abort = TRUE;
+        PayloadAborted = TRUE;
       } else {
         if (ResetRequired != NULL) {
           *ResetRequired |= ResetRequiredBuffer[Index2];
@@ -1353,6 +1362,17 @@ ProcessFmpCapsuleImage (
         );
     }
 
+    if (PayloadAborted) {
+      // This payload caused the failure.
+      ReportAddPayload (CapsuleResult, Status);
+    } else if (Abort) {
+      // An earlier payload caused the failure.
+      ReportAddPayload (CapsuleResult, EFI_ABORTED);
+    } else {
+      // Success so far.
+      ReportAddPayload (CapsuleResult, EFI_SUCCESS);
+    }
+
     if (HandleBuffer != NULL) {
       FreePool (HandleBuffer);
     }
@@ -1360,6 +1380,10 @@ ProcessFmpCapsuleImage (
     if (ResetRequiredBuffer != NULL) {
       FreePool (ResetRequiredBuffer);
     }
+  }
+
+  if (Abort) {
+    ReportCapsuleOutcome (CapsuleResult, CAPSULE_PAYLOAD, EFI_ABORTED);
   }
 
   if (NotReady) {
@@ -1539,9 +1563,10 @@ SupportCapsuleImage (
 
   Caution: This function may receive untrusted input.
 
-  @param[in]  CapsuleHeader         Points to a capsule header.
-  @param[in]  CapFileName           Capsule file name.
-  @param[out] ResetRequired         Indicates whether reset is required or not.
+  @param[in]     CapsuleHeader      Points to a capsule header.
+  @param[in]     CapFileName        Capsule file name.
+  @param[out]    ResetRequired      Indicates whether reset is required or not.
+  @param[in,out] CapsuleResult      Outcome of processing the capsule.
 
   @retval EFI_SUCESS            Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
@@ -1553,7 +1578,8 @@ EFIAPI
 ProcessThisCapsuleImage (
   IN EFI_CAPSULE_HEADER  *CapsuleHeader,
   IN CHAR16              *CapFileName   OPTIONAL,
-  OUT BOOLEAN            *ResetRequired OPTIONAL
+  OUT BOOLEAN            *ResetRequired OPTIONAL,
+  IN OUT CapsuleResult   *CapsuleResult OPTIONAL
   )
 {
   EFI_STATUS  Status;
@@ -1583,6 +1609,7 @@ ProcessThisCapsuleImage (
     DEBUG ((DEBUG_INFO, "ValidateFmpCapsule - %r\n", Status));
     if (EFI_ERROR (Status)) {
       RecordCapsuleStatusVariable (CapsuleHeader, Status);
+      ReportCapsuleOutcome (CapsuleResult, CAPSULE_NONFMP, Status);
       return Status;
     }
 
@@ -1590,7 +1617,7 @@ ProcessThisCapsuleImage (
     // Process EFI FMP Capsule
     //
     DEBUG ((DEBUG_INFO, "ProcessFmpCapsuleImage ...\n"));
-    Status = ProcessFmpCapsuleImage (CapsuleHeader, CapFileName, ResetRequired);
+    Status = ProcessFmpCapsuleImage (CapsuleHeader, CapFileName, ResetRequired, CapsuleResult);
     DEBUG ((DEBUG_INFO, "ProcessFmpCapsuleImage - %r\n", Status));
 
     return Status;
@@ -1617,7 +1644,7 @@ ProcessCapsuleImage (
   IN EFI_CAPSULE_HEADER  *CapsuleHeader
   )
 {
-  return ProcessThisCapsuleImage (CapsuleHeader, NULL, NULL);
+  return ProcessThisCapsuleImage (CapsuleHeader, NULL, NULL, NULL);
 }
 
 /**

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -72,6 +72,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdCodRelocationDevPath                     ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCoDRelocationFileName                    ## CONSUMES
 
+  gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleReport                      ## SOMETIMES_CONSUMES
+
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset ## CONSUMES
 

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -31,10 +31,12 @@
   DxeCapsuleReportLib.c
   CapsuleOnDisk.c
   CapsuleOnDisk.h
+  UpdateReport.c
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -52,6 +54,7 @@
   FileHandleLib
   UefiBootManagerLib
   VariablePolicyHelperLib
+  PopUpLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleMax                               ## CONSUMES

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -37,6 +37,7 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   DasharoPayloadPkg/DasharoPayloadPkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -55,6 +56,8 @@
   UefiBootManagerLib
   VariablePolicyHelperLib
   PopUpLib
+  UefiLib
+  FmpDependencyLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleMax                               ## CONSUMES
@@ -102,6 +105,7 @@
   ## SOMETIMES_PRODUCES ## Variable:L"BootNext"
   gEfiGlobalVariableGuid
   gEdkiiCapsuleOnDiskNameGuid             ## SOMETIMES_CONSUMES ## GUID
+  gEfiSystemResourceTableGuid             ## SOMETIMES_CONSUMES ## GUID
 
 [Depex]
   gEfiVariableWriteArchProtocolGuid

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -33,6 +33,8 @@
 
 #include <IndustryStandard/WindowsUxCapsule.h>
 
+#include "UpdateReport.h"
+
 extern EDKII_FIRMWARE_MANAGEMENT_PROGRESS_PROTOCOL  *mFmpProgress;
 
 /**
@@ -135,9 +137,10 @@ UINT32      mCapsuleTotalNumber;
 
   Caution: This function may receive untrusted input.
 
-  @param[in]  CapsuleHeader         Points to a capsule header.
-  @param[in]  CapFileName           Capsule file name.
-  @param[out] ResetRequired         Indicates whether reset is required or not.
+  @param[in]     CapsuleHeader      Points to a capsule header.
+  @param[in]     CapFileName        Capsule file name.
+  @param[out]    ResetRequired      Indicates whether reset is required or not.
+  @param[in,out] CapsuleResult      Outcome of processing the capsule.
 
   @retval EFI_SUCESS            Process Capsule Image successfully.
   @retval EFI_UNSUPPORTED       Capsule image is not supported by the firmware.
@@ -149,7 +152,8 @@ EFIAPI
 ProcessThisCapsuleImage (
   IN EFI_CAPSULE_HEADER  *CapsuleHeader,
   IN CHAR16              *CapFileName   OPTIONAL,
-  OUT BOOLEAN            *ResetRequired OPTIONAL
+  OUT BOOLEAN            *ResetRequired OPTIONAL,
+  IN OUT CapsuleResult   *CapsuleResult OPTIONAL
   );
 
 /**
@@ -543,8 +547,9 @@ PopulateCapsuleInConfigurationTable (
 
   Each individual capsule result is recorded in capsule record variable.
 
-  @param[in]  FirstRound         TRUE:  First round. Need skip the FMP capsules with non zero EmbeddedDriverCount.
+  @param[in]      FirstRound     TRUE:  First round. Need skip the FMP capsules with non zero EmbeddedDriverCount.
                                  FALSE: Process rest FMP capsules.
+  @param[in,out]  Report         Pointer to a capsule update report.
 
   @retval EFI_SUCCESS             There is no error when processing capsules.
   @retval EFI_OUT_OF_RESOURCES    No enough resource to process capsules.
@@ -552,7 +557,8 @@ PopulateCapsuleInConfigurationTable (
 **/
 EFI_STATUS
 ProcessTheseCapsules (
-  IN BOOLEAN  FirstRound
+  IN BOOLEAN           FirstRound,
+  IN OUT UpdateReport  *Report
   )
 {
   EFI_STATUS                Status;
@@ -562,6 +568,7 @@ ProcessTheseCapsules (
   UINT16                    EmbeddedDriverCount;
   BOOLEAN                   ResetRequired;
   CHAR16                    *CapsuleName;
+  CapsuleResult             *CapsuleResult;
 
   DEBUG ((DEBUG_ERROR, "%a(): Round #%d.\n", __func__, FirstRound ? 1 : 2));
 
@@ -605,11 +612,15 @@ ProcessTheseCapsules (
     CapsuleHeader = (EFI_CAPSULE_HEADER *)mCapsulePtr[Index];
     CapsuleName   = (mCapsuleNamePtr == NULL) ? NULL : mCapsuleNamePtr[Index];
     if (CompareGuid (&CapsuleHeader->CapsuleGuid, &gWindowsUxCapsuleGuid)) {
+      CapsuleResult = ReportAddCapsule (Report, Index);
+
       DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage (Ux) - 0x%x\n", CapsuleHeader));
       DEBUG ((DEBUG_INFO, "Display logo capsule is found.\n"));
-      Status                     = ProcessThisCapsuleImage (CapsuleHeader, CapsuleName, NULL);
+      Status                     = ProcessThisCapsuleImage (CapsuleHeader, CapsuleName, NULL, CapsuleResult);
       mCapsuleStatusArray[Index] = EFI_SUCCESS;
       DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage (Ux) - %r\n", Status));
+
+      ReportCapsuleOutcome (CapsuleResult, CAPSULE_SUCCESS, Status);
       break;
     }
   }
@@ -636,26 +647,32 @@ ProcessTheseCapsules (
         Status = ValidateFmpCapsule (CapsuleHeader, &EmbeddedDriverCount);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "ValidateFmpCapsule failed. Ignore!\n"));
+          ReportCapsuleOutcome (ReportAddCapsule (Report, Index), CAPSULE_REFUSED, Status);
           mCapsuleStatusArray[Index] = EFI_ABORTED;
           continue;
         }
       } else {
+        ReportCapsuleOutcome (ReportAddCapsule (Report, Index), CAPSULE_NONFMP, EFI_ABORTED);
         mCapsuleStatusArray[Index] = EFI_ABORTED;
         continue;
       }
 
       if ((!FirstRound) || (EmbeddedDriverCount == 0)) {
+        CapsuleResult = ReportAddCapsule (Report, Index);
+
         DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage - 0x%x\n", CapsuleHeader));
         ResetRequired              = FALSE;
-        Status                     = ProcessThisCapsuleImage (CapsuleHeader, CapsuleName, &ResetRequired);
+        Status                     = ProcessThisCapsuleImage (CapsuleHeader, CapsuleName, &ResetRequired, CapsuleResult);
         mCapsuleStatusArray[Index] = Status;
         DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage - %r\n", Status));
 
         if (Status != EFI_NOT_READY) {
           if (EFI_ERROR (Status)) {
+            ReportCapsuleOutcome (CapsuleResult, CAPSULE_FAILED, Status);
             REPORT_STATUS_CODE (EFI_ERROR_CODE, (EFI_SOFTWARE | PcdGet32 (PcdStatusCodeSubClassCapsule) | PcdGet32 (PcdCapsuleStatusCodeUpdateFirmwareFailed)));
             DEBUG ((DEBUG_ERROR, "Capsule process failed!\n"));
           } else {
+            ReportCapsuleOutcome (CapsuleResult, CAPSULE_SUCCESS, Status);
             REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE | PcdGet32 (PcdStatusCodeSubClassCapsule) | PcdGet32 (PcdCapsuleStatusCodeUpdateFirmwareSuccess)));
           }
 
@@ -663,6 +680,12 @@ ProcessTheseCapsules (
           if ((CapsuleHeader->Flags & PcdGet16 (PcdSystemRebootAfterCapsuleProcessFlag)) != 0) {
             mNeedReset = TRUE;
           }
+        } else if (!FirstRound) {
+          // Capsule GUID wasn't matched against any FMP instance.
+          ReportCapsuleOutcome (CapsuleResult, CAPSULE_REJECTED, Status);
+        } else {
+          // This capsule will be revisited.
+          ReportPopCapsule (Report);
         }
       }
     }
@@ -681,6 +704,16 @@ ProcessTheseCapsules (
   REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE | PcdGet32 (PcdStatusCodeSubClassCapsule) | PcdGet32 (PcdCapsuleStatusCodeProcessCapsulesEnd)));
 
   return Status;
+}
+
+STATIC
+VOID
+FinishCapsuleUpdate (
+  IN UpdateReport  *Report
+  )
+{
+  ReportDisplay (Report);
+  ReportFree (Report);
 }
 
 /**
@@ -737,10 +770,12 @@ ProcessCapsules (
   VOID
   )
 {
+  STATIC UpdateReport  CapsuleReport;
+
   EFI_STATUS  Status;
 
   if (!mDxeCapsuleLibEndOfDxe) {
-    Status = ProcessTheseCapsules (TRUE);
+    Status = ProcessTheseCapsules (TRUE, &CapsuleReport);
 
     //
     // Reboot System if and only if all capsule processed.
@@ -752,10 +787,14 @@ ProcessCapsules (
     if (mNeedReset &&
         (!CoDCheckCapsuleOnDiskFlag () || mCapsuleTotalNumber != 0) &&
         AreAllImagesProcessed ()) {
+      FinishCapsuleUpdate (&CapsuleReport);
       DoResetSystem ();
     }
   } else {
-    Status = ProcessTheseCapsules (FALSE);
+    Status = ProcessTheseCapsules (FALSE, &CapsuleReport);
+
+    FinishCapsuleUpdate (&CapsuleReport);
+
     //
     // Reboot System if required after all capsule processed
     //

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -612,7 +612,7 @@ ProcessTheseCapsules (
     CapsuleHeader = (EFI_CAPSULE_HEADER *)mCapsulePtr[Index];
     CapsuleName   = (mCapsuleNamePtr == NULL) ? NULL : mCapsuleNamePtr[Index];
     if (CompareGuid (&CapsuleHeader->CapsuleGuid, &gWindowsUxCapsuleGuid)) {
-      CapsuleResult = ReportAddCapsule (Report, Index);
+      CapsuleResult = ReportAddCapsule (Report, Index, CapsuleHeader);
 
       DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage (Ux) - 0x%x\n", CapsuleHeader));
       DEBUG ((DEBUG_INFO, "Display logo capsule is found.\n"));
@@ -647,18 +647,18 @@ ProcessTheseCapsules (
         Status = ValidateFmpCapsule (CapsuleHeader, &EmbeddedDriverCount);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "ValidateFmpCapsule failed. Ignore!\n"));
-          ReportCapsuleOutcome (ReportAddCapsule (Report, Index), CAPSULE_REFUSED, Status);
+          ReportCapsuleOutcome (ReportAddCapsule (Report, Index, CapsuleHeader), CAPSULE_REFUSED, Status);
           mCapsuleStatusArray[Index] = EFI_ABORTED;
           continue;
         }
       } else {
-        ReportCapsuleOutcome (ReportAddCapsule (Report, Index), CAPSULE_NONFMP, EFI_ABORTED);
+        ReportCapsuleOutcome (ReportAddCapsule (Report, Index, CapsuleHeader), CAPSULE_NONFMP, EFI_ABORTED);
         mCapsuleStatusArray[Index] = EFI_ABORTED;
         continue;
       }
 
       if ((!FirstRound) || (EmbeddedDriverCount == 0)) {
-        CapsuleResult = ReportAddCapsule (Report, Index);
+        CapsuleResult = ReportAddCapsule (Report, Index, CapsuleHeader);
 
         DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage - 0x%x\n", CapsuleHeader));
         ResetRequired              = FALSE;

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
@@ -38,6 +38,7 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   DasharoPayloadPkg/DasharoPayloadPkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -52,6 +53,8 @@
   HobLib
   BmpSupportLib
   PopUpLib
+  UefiLib
+  FmpDependencyLib
 
 [Pcd]
   gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleReport  ## SOMETIMES_CONSUMES
@@ -74,6 +77,7 @@
   gEfiEventExitBootServicesGuid           ## CONSUMES ## Event
   gEfiEventVirtualAddressChangeGuid       ## CONSUMES ## Event
   gEdkiiCapsuleOnDiskNameGuid             ## SOMETIMES_CONSUMES ## GUID
+  gEfiSystemResourceTableGuid             ## SOMETIMES_CONSUMES ## GUID
 
 [Depex]
   gEfiVariableWriteArchProtocolGuid

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
@@ -53,6 +53,9 @@
   BmpSupportLib
   PopUpLib
 
+[Pcd]
+  gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleReport  ## SOMETIMES_CONSUMES
+
 [Protocols]
   gEsrtManagementProtocolGuid                   ## CONSUMES
   gEfiFirmwareManagementProtocolGuid            ## CONSUMES

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
@@ -32,10 +32,12 @@
   DxeCapsuleProcessLibNull.c
   DxeCapsuleReportLibNull.c
   DxeCapsuleRuntime.c
+  UpdateReport.c
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -49,7 +51,7 @@
   PrintLib
   HobLib
   BmpSupportLib
-
+  PopUpLib
 
 [Protocols]
   gEsrtManagementProtocolGuid                   ## CONSUMES

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
@@ -1,0 +1,330 @@
+#include "UpdateReport.h"
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/CustomizedDisplayLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PopUpLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+VOID
+EFIAPI
+ReportFree (
+  IN OUT UpdateReport  *Report
+  )
+{
+  UINTN          CapsuleIdx;
+  CapsuleResult  *Capsule;
+
+  for (CapsuleIdx = 0; CapsuleIdx < Report->CapsuleCount; ++CapsuleIdx) {
+    Capsule = &Report->Capsules[CapsuleIdx];
+    if (Capsule->Payloads != NULL) {
+      FreePool (Capsule->Payloads);
+    }
+  }
+
+  if (Report->Capsules != NULL) {
+    FreePool (Report->Capsules);
+  }
+}
+
+CapsuleResult *
+EFIAPI
+ReportAddCapsule (
+  IN UpdateReport  *Report,
+  IN UINTN         Index
+  )
+{
+  VOID           *Capsules;
+  CapsuleResult  *CapsuleResult;
+
+  Capsules = ReallocatePool (Report->CapsuleCount * sizeof(*Report->Capsules),
+                             (Report->CapsuleCount + 1) * sizeof(*Report->Capsules),
+                             Report->Capsules);
+  if (Capsules == NULL) {
+    return NULL;
+  }
+
+  Report->Capsules = Capsules;
+
+  CapsuleResult = &Report->Capsules[Report->CapsuleCount++];
+
+  CapsuleResult->Index   = Index;
+  CapsuleResult->Outcome = CAPSULE_UNKNOWN;
+  CapsuleResult->Status  = EFI_SUCCESS;
+
+  return CapsuleResult;
+}
+
+VOID
+EFIAPI
+ReportPopCapsule (
+  IN UpdateReport  *Report
+  )
+{
+  CapsuleResult  *Capsule;
+
+  if (Report->CapsuleCount == 0) {
+    return;
+  }
+
+  Capsule = &Report->Capsules[--Report->CapsuleCount];
+  if (Capsule->Payloads != NULL) {
+    FreePool (Capsule->Payloads);
+  }
+}
+
+VOID
+EFIAPI
+ReportCapsuleOutcome (
+  IN CapsuleResult  *CapsuleResult OPTIONAL,
+  IN UpdateOutcome  Outcome,
+  IN EFI_STATUS     Status
+  )
+{
+  if (CapsuleResult == NULL) {
+    return;
+  }
+
+  //
+  // Permit code deeper in the call stack to set a more specific failure reason
+  // in which case this will do nothing when a higher-level function tries to
+  // set a generic failure.
+  //
+  if (CapsuleResult->Outcome == CAPSULE_UNKNOWN) {
+    CapsuleResult->Outcome = Outcome;
+    CapsuleResult->Status  = Status;
+  }
+}
+
+VOID
+EFIAPI
+ReportAddPayload (
+  IN OUT CapsuleResult  *Capsule OPTIONAL,
+  IN EFI_STATUS         Status
+  )
+{
+  VOID           *Payloads;
+  PayloadResult  *PayloadResult;
+
+  if (Capsule == NULL) {
+    return;
+  }
+
+  Payloads = ReallocatePool (Capsule->PayloadCount * sizeof(*Capsule->Payloads),
+                             (Capsule->PayloadCount + 1) * sizeof(*Capsule->Payloads),
+                             Capsule->Payloads);
+  if (Payloads == NULL) {
+    return;
+  }
+
+  Capsule->Payloads = Payloads;
+
+  PayloadResult = &Capsule->Payloads[Capsule->PayloadCount++];
+
+  PayloadResult->Status = Status;
+}
+
+STATIC
+BOOLEAN
+EFIAPI
+AllUpdatesSuccessful (
+  IN CONST UpdateReport  *Report
+  )
+{
+  UINTN  CapsuleIdx;
+
+  for (CapsuleIdx = 0; CapsuleIdx < Report->CapsuleCount; ++CapsuleIdx) {
+    if (Report->Capsules[CapsuleIdx].Outcome != CAPSULE_SUCCESS) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+STATIC
+CONST CHAR16 *
+OutcomeToString (
+  IN UpdateOutcome  Outcome
+  )
+{
+  switch (Outcome) {
+    case CAPSULE_UNKNOWN:  return L"BUG: not set";
+    case CAPSULE_REJECTED: return L"Firmware GUID wasn't recognized";
+    case CAPSULE_REFUSED:  return L"Capsule has failed FMP validation";
+    case CAPSULE_NONFMP:   return L"Capsule is not of FMP type";
+    case CAPSULE_FAILED:   return L"Update process hit an error";
+    case CAPSULE_DRIVER:   return L"Failed to start a driver";
+    case CAPSULE_PAYLOAD:  return L"Failed to set a payload image";
+    case CAPSULE_SUCCESS:  return L"Applied successfully";
+  }
+
+  return L"BUG: unhandled value of a CAPSULE_* constant!";
+}
+
+STATIC
+VOID
+EFIAPI
+ReportResults (
+  IN OUT PopUpData       *PopUp,
+  IN CONST UpdateReport  *Report
+  )
+{
+  UINTN                CapsuleIdx;
+  UINTN                PayloadIdx;
+  CONST CapsuleResult  *Capsule;
+  CONST PayloadResult  *Payload;
+
+  for (CapsuleIdx = 0; CapsuleIdx < Report->CapsuleCount; ++CapsuleIdx) {
+    Capsule = &Report->Capsules[CapsuleIdx];
+
+    //
+    // Note that lines can't start with a space as then they are drawn as
+    // input fields.
+    //
+
+    if (Report->CapsuleCount > 1) {
+      AddFullLineF (PopUp, L"Capsule #%d", Capsule->Index + 1);
+    }
+    AddFullLineF (PopUp, L"- Result: %s", OutcomeToString (Capsule->Outcome));
+    if (Capsule->Status != EFI_SUCCESS) {
+      AddFullLineF (PopUp, L"- Status: %r", Capsule->Status);
+    }
+
+    for (PayloadIdx = 0; PayloadIdx < Capsule->PayloadCount; ++PayloadIdx) {
+      Payload = &Capsule->Payloads[PayloadIdx];
+      if (Capsule->PayloadCount > 1) {
+        AddFullLineF (PopUp, L"- Status of payload #%d: %r", PayloadIdx + 1, Payload->Status);
+      } else {
+        AddFullLineF (PopUp, L"- Status of payload: %r", Payload->Status);
+      }
+    }
+
+    if (Capsule->PayloadCount == 0) {
+      AddFullLine (PopUp, L"- No payloads were processed.");
+    }
+  }
+}
+
+STATIC
+VOID
+WaitForEnterKey (
+  IN UINTN  TimeoutSeconds
+  )
+{
+  EFI_STATUS     Status;
+  EFI_EVENT      Events[2];
+  UINTN          EventCount;
+  UINTN          EventIndex;
+  EFI_INPUT_KEY  Key;
+  EFI_EVENT      TimerEvent;
+
+  EventCount = 0;
+  Events[EventCount++] = gST->ConIn->WaitForKey;
+  if (TimeoutSeconds > 0) {
+    Status = gBS->CreateEvent (
+        EVT_TIMER,
+        TPL_CALLBACK,
+        NULL,
+        NULL,
+        &TimerEvent
+        );
+    if (EFI_ERROR (Status) ||
+        EFI_ERROR (gBS->SetTimer (TimerEvent, TimerRelative, TimeoutSeconds * 1000 * 1000 * 10))) {
+      if (!EFI_ERROR (Status)) {
+        gBS->CloseEvent (TimerEvent);
+      }
+      // It was just a notice anyway, give up.
+      return;
+    }
+
+    Events[EventCount++] = TimerEvent;
+  }
+
+  DrainInput ();
+
+  while (TRUE) {
+    Status = gBS->WaitForEvent (EventCount, Events, &EventIndex);
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    // Reached a timeout.
+    if (EventIndex == 1) {
+      break;
+    }
+
+    // Received a key press.
+    if (EventIndex == 0) {
+      Status = gST->ConIn->ReadKeyStroke (gST->ConIn, &Key);
+      if (!EFI_ERROR (Status) && Key.UnicodeChar == CHAR_CARRIAGE_RETURN) {
+        break;
+      }
+    }
+  }
+
+  if (TimeoutSeconds > 0) {
+    gBS->CloseEvent (TimerEvent);
+  }
+}
+
+VOID
+EFIAPI
+ReportDisplay (
+  IN CONST UpdateReport  *Report
+  )
+{
+  PopUpData  PopUp;
+  BOOLEAN    Success;
+
+  PopUpInit (&PopUp, /*Width=*/78);
+
+  if (Report->CapsuleCount == 0) {
+    Success = FALSE;
+    AddTitle (&PopUp, L"Firmware Update Skipped");
+    AddLine (&PopUp, L"The firmware is in capsule update mode, yet no update capsules were");
+    AddLine (&PopUp, L"discovered. The update was cancelled without modifying the firmware.");
+    AddLine (&PopUp, L"");
+    AddLine (&PopUp, L"This situation is unexpected. Please consider contacting us at");
+    AddLine (&PopUp, L"support@dasharo.com describing how this situation occurred.");
+  } else if (AllUpdatesSuccessful (Report)) {
+    Success = TRUE;
+    AddTitle (&PopUp, L"Firmware Update Succeeded");
+    if (Report->CapsuleCount == 1) {
+      AddLine (&PopUp, L"Successfully applied a firmware update.");
+    } else {
+      AddLineF (&PopUp, L"Successfully applied all firmware updates (%d capsules).", Report->CapsuleCount);
+    }
+  } else {
+    Success = FALSE;
+    AddTitle (&PopUp, L"Firmware Update Failed");
+    if (Report->CapsuleCount == 1) {
+      AddLine (&PopUp, L"A firmware update was not applied successfully. Depending on the severity of");
+      AddLine (&PopUp, L"the error the device may be unbootable and require external firmware flashing.");
+    } else {
+      AddLine (&PopUp, L"Not all firmware updates were applied successfully. Depending on the severity");
+      AddLine (&PopUp, L"of the error the device may be unbootable and require external firmware");
+      AddLine (&PopUp, L"flashing.");
+    }
+    AddLine (&PopUp, L"");
+    AddLine (&PopUp, L"Please contact us at support@dasharo.com with a photo of the screen and refer");
+    AddLine (&PopUp, L"to the device-specific recovery instructions at <https://docs.dasharo.com>.");
+    AddLine (&PopUp, L"");
+    AddLine (&PopUp, L"Details about the update:");
+    ReportResults (&PopUp, Report);
+  }
+
+  AddLine (&PopUp, L"");
+  if (Success) {
+    AddLine (&PopUp, L"The system will reboot in 30 seconds, press ENTER to reboot immediately.");
+  } else {
+    AddLine (&PopUp, L"Press ENTER to reboot.");
+  }
+
+  PopUpDraw (&PopUp, Success ? SuccessPopUp : ErrorPopUp);
+
+  WaitForEnterKey (Success ? 30 : 0);
+}

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
@@ -280,6 +280,10 @@ ReportDisplay (
   PopUpData  PopUp;
   BOOLEAN    Success;
 
+  if (!FixedPcdGetBool (PcdShowCapsuleReport)) {
+    return;
+  }
+
   PopUpInit (&PopUp, /*Width=*/78);
 
   if (Report->CapsuleCount == 0) {

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
@@ -430,6 +430,42 @@ ReportVersions (
 }
 
 STATIC
+CONST EFI_GUID *
+GetFirstPayloadFwClass (
+  IN CONST CapsuleResult  *Capsule
+  )
+{
+  UINTN                                         PayloadIdx;
+  UINTN                                         ItemCount;
+  EFI_CAPSULE_HEADER                            *Header;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER        *FmpHdr;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *FmpImageHdr;
+  UINT64                                        *ItemOffsetList;
+
+  Header = Capsule->Header;
+  if (!IsFmpCapsule (Header)) {
+    return NULL;
+  }
+
+  // An FMP capsule can be nested which is checked for in IsFmpCapsule().
+  if (!IsFmpCapsuleGuid (&Header->CapsuleGuid)) {
+    Header = (VOID *)((UINT8 *)Header + Header->HeaderSize);
+  }
+
+  FmpHdr         = (VOID *)((UINT8 *)Header + Header->HeaderSize);
+  ItemCount      = FmpHdr->EmbeddedDriverCount + FmpHdr->PayloadItemCount;
+  ItemOffsetList = (UINT64 *)&FmpHdr[1];
+
+  PayloadIdx = FmpHdr->EmbeddedDriverCount;
+  if (PayloadIdx < ItemCount) {
+    FmpImageHdr = (VOID *)((UINT8 *)FmpHdr + ItemOffsetList[PayloadIdx]);
+    return &FmpImageHdr->UpdateImageTypeId;
+  }
+
+  return NULL;
+}
+
+STATIC
 VOID
 EFIAPI
 ReportResults (
@@ -441,6 +477,7 @@ ReportResults (
   UINTN                PayloadIdx;
   CONST CapsuleResult  *Capsule;
   CONST PayloadResult  *Payload;
+  CONST EFI_GUID       *FwClass;
 
   for (CapsuleIdx = 0; CapsuleIdx < Report->CapsuleCount; ++CapsuleIdx) {
     Capsule = &Report->Capsules[CapsuleIdx];
@@ -453,9 +490,19 @@ ReportResults (
     if (Report->CapsuleCount > 1) {
       AddFullLineF (PopUp, L"Capsule #%d", Capsule->Index + 1);
     }
-    AddFullLineF (PopUp, L"- Result: %s", OutcomeToString (Capsule->Outcome));
-    if (Capsule->Status != EFI_SUCCESS) {
-      AddFullLineF (PopUp, L"- Status: %r", Capsule->Status);
+
+    // Can print GUIDs of all payloads if we'll ever use such capsules.
+    FwClass = GetFirstPayloadFwClass (Capsule);
+    if (FwClass == NULL) {
+      AddFullLine (PopUp, L"- GUID: unknown");
+    } else {
+      AddFullLineF (PopUp, L"- GUID: %g", FwClass);
+    }
+
+    if (Capsule->Status == EFI_SUCCESS) {
+      AddFullLineF (PopUp, L"- Result: %s", OutcomeToString (Capsule->Outcome));
+    } else {
+      AddFullLineF (PopUp, L"- Result: %s (error: %r)", OutcomeToString (Capsule->Outcome), Capsule->Status);
     }
 
     for (PayloadIdx = 0; PayloadIdx < Capsule->PayloadCount; ++PayloadIdx) {

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
@@ -1,13 +1,69 @@
 #include "UpdateReport.h"
 
+#include <Guid/FmpCapsule.h>
+#include <Guid/SystemResourceTable.h>
+
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/CustomizedDisplayLib.h>
 #include <Library/DebugLib.h>
+#include <Library/FmpDependencyLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PopUpLib.h>
 #include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+#pragma pack(1)
+
+typedef struct {
+  UINT32  Signature;
+  UINT32  HeaderSize;
+  UINT32  FwVersion;
+  UINT32  LowestSupportedVersion;
+} FMP_PAYLOAD_HEADER;
+
+#pragma pack()
+
+#define FMP_PAYLOAD_HEADER_SIGNATURE  SIGNATURE_32 ('M', 'S', 'S', '1')
+
+/**
+  Return if this CapsuleGuid is a FMP capsule GUID or not.
+
+  @param[in] CapsuleGuid A pointer to EFI_GUID
+
+  @retval TRUE  It is a FMP capsule GUID.
+  @retval FALSE It is not a FMP capsule GUID.
+**/
+BOOLEAN
+IsFmpCapsuleGuid (
+  IN EFI_GUID  *CapsuleGuid
+  );
+
+/**
+  Return if this FMP is a system FMP or a device FMP, based upon CapsuleHeader.
+
+  @param[in] CapsuleHeader A pointer to EFI_CAPSULE_HEADER
+
+  @retval TRUE  It is a system FMP.
+  @retval FALSE It is a device FMP.
+**/
+BOOLEAN
+IsFmpCapsule (
+  IN EFI_CAPSULE_HEADER  *CapsuleHeader
+  );
+
+/**
+  Gets pointer to the image data from payload's header.
+
+  @param[in]  ImageHeader   The payload image header.
+
+  @return The pointer to the start of the image data.
+**/
+VOID *
+GetFmpImage (
+  IN EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *ImageHeader
+  );
 
 VOID
 EFIAPI
@@ -33,8 +89,9 @@ ReportFree (
 CapsuleResult *
 EFIAPI
 ReportAddCapsule (
-  IN UpdateReport  *Report,
-  IN UINTN         Index
+  IN UpdateReport        *Report,
+  IN UINTN               Index,
+  IN EFI_CAPSULE_HEADER  *Header
   )
 {
   VOID           *Capsules;
@@ -52,6 +109,7 @@ ReportAddCapsule (
   CapsuleResult = &Report->Capsules[Report->CapsuleCount++];
 
   CapsuleResult->Index   = Index;
+  CapsuleResult->Header  = Header;
   CapsuleResult->Outcome = CAPSULE_UNKNOWN;
   CapsuleResult->Status  = EFI_SUCCESS;
 
@@ -163,6 +221,160 @@ OutcomeToString (
   }
 
   return L"BUG: unhandled value of a CAPSULE_* constant!";
+}
+
+STATIC
+BOOLEAN
+FindEsre (
+  IN OUT CONST EFI_SYSTEM_RESOURCE_ENTRY  **Entry
+  )
+{
+  EFI_STATUS                 Status;
+  UINTN                      Index;
+  EFI_SYSTEM_RESOURCE_ENTRY  *Esre;
+  EFI_SYSTEM_RESOURCE_TABLE  *Esrt;
+
+  Status = EfiGetSystemConfigurationTable (&gEfiSystemResourceTableGuid, (VOID **)&Esrt);
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  Esre = (VOID *)&Esrt[1];
+  for (Index = 0; Index < Esrt->FwResourceCount; ++Index) {
+    if (Esre[Index].FwType == ESRT_FW_TYPE_SYSTEMFIRMWARE) {
+      *Entry = &Esre[Index];
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+STATIC
+BOOLEAN
+GetNewBiosVersion (
+  IN CONST UpdateReport               *Report,
+  IN CONST EFI_SYSTEM_RESOURCE_ENTRY  *Esre,
+  OUT UINT32                          *NewVersion
+  )
+{
+  UINTN                                         CapsuleIdx;
+  UINTN                                         PayloadIdx;
+  UINTN                                         ItemCount;
+  UINT32                                        DepExSize;
+  CONST CapsuleResult                           *Capsule;
+  EFI_CAPSULE_HEADER                            *Header;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER        *FmpHdr;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *FmpImageHdr;
+  EFI_FIRMWARE_IMAGE_AUTHENTICATION             *FmpImage;
+  FMP_PAYLOAD_HEADER                            *FmpPayloadHdr;
+  UINT64                                        *ItemOffsetList;
+
+  // We want to get the version from the last capsule in case more than one was
+  // applied in a succession.
+  for (CapsuleIdx = Report->CapsuleCount; CapsuleIdx > 0; --CapsuleIdx) {
+    Capsule = &Report->Capsules[CapsuleIdx - 1];
+
+    if (Capsule->Outcome != CAPSULE_SUCCESS) {
+      continue;
+    }
+
+    Header = Capsule->Header;
+    if (!IsFmpCapsule (Header)) {
+      continue;
+    }
+
+    // An FMP capsule can be nested which is checked for in IsFmpCapsule().
+    if (!IsFmpCapsuleGuid (&Header->CapsuleGuid)) {
+      Header = (VOID *)((UINT8 *)Header + Header->HeaderSize);
+    }
+
+    FmpHdr         = (VOID *)((UINT8 *)Header + Header->HeaderSize);
+    ItemCount      = FmpHdr->EmbeddedDriverCount + FmpHdr->PayloadItemCount;
+    ItemOffsetList = (UINT64 *)&FmpHdr[1];
+
+    for (PayloadIdx = FmpHdr->EmbeddedDriverCount; PayloadIdx < ItemCount; ++PayloadIdx) {
+      FmpImageHdr = (VOID *)((UINT8 *)FmpHdr + ItemOffsetList[PayloadIdx]);
+
+      if (!CompareGuid (&Esre->FwClass, &FmpImageHdr->UpdateImageTypeId)) {
+        continue;
+      }
+
+      FmpImage = GetFmpImage (FmpImageHdr);
+
+      DepExSize = 0;
+      GetImageDependency (FmpImage, FmpImageHdr->UpdateImageSize, &DepExSize, NULL);
+
+      FmpPayloadHdr = (VOID *)((UINT8 *)FmpImage +
+                               sizeof(FmpImage->MonotonicCount) +
+                               FmpImage->AuthInfo.Hdr.dwLength +
+                               DepExSize);
+      if (FmpPayloadHdr->Signature == FMP_PAYLOAD_HEADER_SIGNATURE) {
+        *NewVersion = FmpPayloadHdr->FwVersion;
+        return TRUE;
+      }
+    }
+  }
+
+  return FALSE;
+}
+
+STATIC
+VOID
+EFIAPI
+VersionToStr (
+  IN UINT32      Version,
+  IN OUT CHAR16  *Buffer,
+  IN UINTN       BufferSizeBytes
+  )
+{
+  UINTN  Major;
+  UINTN  Minor;
+  UINTN  Patch;
+  UINTN  RcBuild;
+
+  Major   = Version >> 24;
+  Minor   = (Version >> 16) & 0xff;
+  Patch   = (Version >> 8) & 0xff;
+  RcBuild = Version & 0xff;
+
+  if (RcBuild < 0x80) {
+    UnicodeSPrint (Buffer, BufferSizeBytes, L"v%ld.%ld.%ld-rc%ld", Major, Minor, Patch, RcBuild);
+  } else if (RcBuild == 0x80) {
+    UnicodeSPrint (Buffer, BufferSizeBytes, L"v%ld.%ld.%ld", Major, Minor, Patch);
+  } else {
+    UnicodeSPrint (Buffer, BufferSizeBytes, L"v%ld.%ld.%ld.%ld", Major, Minor, Patch, RcBuild - 0x80);
+  }
+}
+
+STATIC
+VOID
+ReportVersions (
+  IN OUT PopUpData       *PopUp,
+  IN CONST UpdateReport  *Report
+  )
+{
+  CONST EFI_SYSTEM_RESOURCE_ENTRY  *Esre;
+  UINT32                           NewVersion;
+  CHAR16                           OldVersionStr[32];
+  CHAR16                           NewVersionStr[32];
+
+  AddLine (PopUp, L"");
+
+  if (!FindEsre (&Esre)) {
+    AddLine (PopUp, L"Failed to determine version of the running firmware!");
+    return;
+  }
+
+  VersionToStr (Esre->FwVersion, OldVersionStr, sizeof(OldVersionStr));
+
+  // It's possible there were no BIOS updates.
+  if (GetNewBiosVersion (Report, Esre, &NewVersion)) {
+    VersionToStr (NewVersion, NewVersionStr, sizeof(NewVersionStr));
+    AddLineF (PopUp, L"Updated from %s to %s.", OldVersionStr, NewVersionStr);
+  } else {
+    AddLineF (PopUp, L"Version of the running firmware: %s", OldVersionStr);
+  }
 }
 
 STATIC
@@ -294,6 +506,7 @@ ReportDisplay (
     AddLine (&PopUp, L"");
     AddLine (&PopUp, L"This situation is unexpected. Please consider contacting us at");
     AddLine (&PopUp, L"support@dasharo.com describing how this situation occurred.");
+    ReportVersions (&PopUp, Report);
   } else if (AllUpdatesSuccessful (Report)) {
     Success = TRUE;
     AddTitle (&PopUp, L"Firmware Update Succeeded");
@@ -302,6 +515,7 @@ ReportDisplay (
     } else {
       AddLineF (&PopUp, L"Successfully applied all firmware updates (%d capsules).", Report->CapsuleCount);
     }
+    ReportVersions (&PopUp, Report);
   } else {
     Success = FALSE;
     AddTitle (&PopUp, L"Firmware Update Failed");
@@ -316,6 +530,7 @@ ReportDisplay (
     AddLine (&PopUp, L"");
     AddLine (&PopUp, L"Please contact us at support@dasharo.com with a photo of the screen and refer");
     AddLine (&PopUp, L"to the device-specific recovery instructions at <https://docs.dasharo.com>.");
+    ReportVersions (&PopUp, Report);
     AddLine (&PopUp, L"");
     AddLine (&PopUp, L"Details about the update:");
     ReportResults (&PopUp, Report);

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
@@ -252,6 +252,58 @@ FindEsre (
 
 STATIC
 BOOLEAN
+BiosUpdateFailed (
+  IN CONST UpdateReport  *Report
+  )
+{
+  UINTN                                         CapsuleIdx;
+  UINTN                                         PayloadIdx;
+  UINTN                                         ItemCount;
+  CONST EFI_SYSTEM_RESOURCE_ENTRY               *Esre;
+  CONST CapsuleResult                           *Capsule;
+  EFI_CAPSULE_HEADER                            *Header;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER        *FmpHdr;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *FmpImageHdr;
+  UINT64                                        *ItemOffsetList;
+
+  if (!FindEsre (&Esre)) {
+    // Assume the worst.
+    return TRUE;
+  }
+
+  // A successful later update overrides any previous failure, so visit the
+  // updates in reverse.
+  for (CapsuleIdx = Report->CapsuleCount; CapsuleIdx > 0; --CapsuleIdx) {
+    Capsule = &Report->Capsules[CapsuleIdx - 1];
+
+    Header = Capsule->Header;
+    if (!IsFmpCapsule (Header)) {
+      continue;
+    }
+
+    // An FMP capsule can be nested which is checked for in IsFmpCapsule().
+    if (!IsFmpCapsuleGuid (&Header->CapsuleGuid)) {
+      Header = (VOID *)((UINT8 *)Header + Header->HeaderSize);
+    }
+
+    FmpHdr         = (VOID *)((UINT8 *)Header + Header->HeaderSize);
+    ItemCount      = FmpHdr->EmbeddedDriverCount + FmpHdr->PayloadItemCount;
+    ItemOffsetList = (UINT64 *)&FmpHdr[1];
+
+    for (PayloadIdx = FmpHdr->EmbeddedDriverCount; PayloadIdx < ItemCount; ++PayloadIdx) {
+      FmpImageHdr = (VOID *)((UINT8 *)FmpHdr + ItemOffsetList[PayloadIdx]);
+
+      if (CompareGuid (&Esre->FwClass, &FmpImageHdr->UpdateImageTypeId)) {
+        return (Capsule->Outcome != CAPSULE_SUCCESS);
+      }
+    }
+  }
+
+  return FALSE;
+}
+
+STATIC
+BOOLEAN
 GetNewBiosVersion (
   IN CONST UpdateReport               *Report,
   IN CONST EFI_SYSTEM_RESOURCE_ENTRY  *Esre,
@@ -519,17 +571,27 @@ ReportDisplay (
   } else {
     Success = FALSE;
     AddTitle (&PopUp, L"Firmware Update Failed");
-    if (Report->CapsuleCount == 1) {
-      AddLine (&PopUp, L"A firmware update was not applied successfully. Depending on the severity of");
-      AddLine (&PopUp, L"the error the device may be unbootable and require external firmware flashing.");
+    if (BiosUpdateFailed (Report)) {
+      if (Report->CapsuleCount == 1) {
+        AddLine (&PopUp, L"A firmware update was not applied successfully.");
+      } else {
+        AddLine (&PopUp, L"Not all firmware updates were applied successfully.");
+      }
+      AddLine (&PopUp, L"Depending on the severity of the error the device may be");
+      AddLine (&PopUp, L"unbootable and require external firmware flashing!");
+      AddLine (&PopUp, L"");
+      AddLine (&PopUp, L"Please contact us at support@dasharo.com with a photo of the screen and refer");
+      AddLine (&PopUp, L"to the device-specific recovery instructions at <https://docs.dasharo.com>.");
     } else {
-      AddLine (&PopUp, L"Not all firmware updates were applied successfully. Depending on the severity");
-      AddLine (&PopUp, L"of the error the device may be unbootable and require external firmware");
-      AddLine (&PopUp, L"flashing.");
+      if (Report->CapsuleCount == 1) {
+        AddLine (&PopUp, L"A firmware update was not applied successfully.");
+      } else {
+        AddLine (&PopUp, L"Not all firmware updates were applied successfully.");
+      }
+      AddLine (&PopUp, L"The system firmware should be intact.");
+      AddLine (&PopUp, L"");
+      AddLine (&PopUp, L"Please contact us at support@dasharo.com with a photo of the screen.");
     }
-    AddLine (&PopUp, L"");
-    AddLine (&PopUp, L"Please contact us at support@dasharo.com with a photo of the screen and refer");
-    AddLine (&PopUp, L"to the device-specific recovery instructions at <https://docs.dasharo.com>.");
     ReportVersions (&PopUp, Report);
     AddLine (&PopUp, L"");
     AddLine (&PopUp, L"Details about the update:");

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.h
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.h
@@ -26,7 +26,9 @@ typedef struct {
 } PayloadResult;
 
 typedef struct {
-  UINTN          Index;  // Because capsules can be processed out of order.
+  UINTN               Index;    // Because capsules can be processed out of order.
+  EFI_CAPSULE_HEADER  *Header;
+
   UpdateOutcome  Outcome;
   EFI_STATUS     Status;
 
@@ -67,8 +69,9 @@ ReportFree (
 CapsuleResult *
 EFIAPI
 ReportAddCapsule (
-  IN UpdateReport  *Report,
-  IN UINTN         Index
+  IN UpdateReport        *Report,
+  IN UINTN               Index,
+  IN EFI_CAPSULE_HEADER  *Header
   );
 
 VOID

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.h
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.h
@@ -1,0 +1,101 @@
+/** @file
+  Means for collecting and reporting information about a capsule update.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+  SPDX-License-Identifier: GPL-2-or-later
+
+**/
+
+#ifndef _UPDATE_REPORT_H_
+#define _UPDATE_REPORT_H_
+
+// This should give an idea where the failure has happened.
+typedef enum {
+  CAPSULE_UNKNOWN,   // Not yet set.
+  CAPSULE_REJECTED,  // Unmatched firmware GUID in the capsule.
+  CAPSULE_REFUSED,   // Capsule has failed early validation.
+  CAPSULE_NONFMP,    // Capsule is not of FMP type.
+  CAPSULE_DRIVER,    // Failed to start a driver.
+  CAPSULE_PAYLOAD,   // Failed to set a payload image.
+  CAPSULE_FAILED,    // Update process hit an error.
+  CAPSULE_SUCCESS,   // Everything went fine.
+} UpdateOutcome;
+
+typedef struct {
+  EFI_STATUS  Status;
+} PayloadResult;
+
+typedef struct {
+  UINTN          Index;  // Because capsules can be processed out of order.
+  UpdateOutcome  Outcome;
+  EFI_STATUS     Status;
+
+  PayloadResult  *Payloads;
+  UINTN          PayloadCount;
+} CapsuleResult;
+
+typedef struct {
+  CapsuleResult  *Capsules;
+  UINTN          CapsuleCount;
+
+  BOOLEAN  Success;
+} UpdateReport;
+
+//
+// The report can be zero initialized, but its resources needs to be freed with
+// ReportFree().
+//
+// Each call to ReportAddCapsule() invalidates the pointer returned by the
+// previous call.  ReportPopCapsule() undoes the most recent ReportAddCapsule().
+//
+// ReportAddCapsule() returns NULL on failure and it's OK to pass this to
+// ReportCapsuleOutcome() and ReportAddPayload().  Can't do much if memory
+// allocation fails, so just collect as much information as possible.
+//
+// ReportCapsuleOutcome() can be called multiple times with result of the first
+// call being preserved.  This gives higher priority to the result set by a
+// nested call while the callee can still set a generic error code when nothing
+// more specific is available.
+//
+
+VOID
+EFIAPI
+ReportFree (
+  IN OUT UpdateReport  *Report
+  );
+
+CapsuleResult *
+EFIAPI
+ReportAddCapsule (
+  IN UpdateReport  *Report,
+  IN UINTN         Index
+  );
+
+VOID
+EFIAPI
+ReportPopCapsule (
+  IN UpdateReport  *Report
+  );
+
+VOID
+EFIAPI
+ReportCapsuleOutcome (
+  IN CapsuleResult  *CapsuleResult OPTIONAL,
+  IN UpdateOutcome  Outcome,
+  IN EFI_STATUS     Status
+  );
+
+VOID
+EFIAPI
+ReportAddPayload (
+  IN OUT CapsuleResult  *Capsule OPTIONAL,
+  IN EFI_STATUS         Status
+  );
+
+VOID
+EFIAPI
+ReportDisplay (
+  IN CONST UpdateReport  *Report
+  );
+
+#endif // _UPDATE_REPORT_H_


### PR DESCRIPTION
This amends capsule update code to collect some fairly high-level information about how things went, still this is more than one gets from capsule result variables and possibly even logs.  The code takes into account possibility of multiple capsules (we don't know what a user of `fwupd` can do) and multiple payloads.

The displaying part reuses the dialog implemented in https://github.com/Dasharo/edk2/pull/285 after making it generally available and also provides code for constructing dialogs which are then displayed as both text (for serial) and graphics (overrides the text on a display), so that both tests and users should be relatively happy.  In the future, we could reuse this code for our other dialogs and have all of them look consistently.

Screenshots are available in https://github.com/Dasharo/dasharo-issues/issues/1434#issuecomment-3752142245.

coreboot PR: https://github.com/Dasharo/coreboot/pull/826
issue: https://github.com/Dasharo/dasharo-issues/issues/1434
*ref: dsh-1127*