### PR TITLE
FmpDeviceSmmLib/Flashing.c: migrate MRC cache across capsule updates

### DIFF
--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -614,6 +614,21 @@ MigrateBootLogo (
 
 STATIC
 BOOLEAN
+MigrateMrcCache (
+  IN CONST MigrationData  *Data
+  )
+{
+  RegionMigrationStatus  Status;
+
+  Status = MigrateRegion ("RW_MRC_CACHE", Data, FALSE);
+
+  return Status == REGION_MIGRATED
+      || Status == REGION_NOT_IN_SRC
+      || Status == REGION_NOT_IN_DST;
+}
+
+STATIC
+BOOLEAN
 MigrateGbeRegion (
   IN CONST MigrationData  *Data
   )
@@ -998,6 +1013,11 @@ MergeFirmwareImages (
 
   if (!MigrateGbeRegion (&Data)) {
     DEBUG ((DEBUG_ERROR, "%a(): MigrateGbeRegion () failed\n", __FUNCTION__));
+    goto Fail;
+  }
+
+  if (!MigrateMrcCache (&Data)) {
+    DEBUG ((DEBUG_ERROR, "%a(): MigrateMrcCache () failed\n", __FUNCTION__));
     goto Fail;
   }
 


### PR DESCRIPTION
MRC cache was being cleared on every capsule update, forcing a full memory retraining cycle on the next boot. This is unnecessary because the cache is versioned by FSP and will be invalidated automatically if the FSP binary changes in the new firmware.

Migrate the RW_MRC_CACHE FMAP region the same way ROMHOLE, BOOTSPLASH and SI_GBE are already handled. The region is not offset-sensitive and its absence in either image is non-fatal.