### PR TITLE
Capsules v2: recovery

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dec
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dec
@@ -104,3 +104,4 @@ gDasharoPayloadPkgTokenSpaceGuid.PcdSerialOnSuperIo|FALSE|BOOLEAN|0x0000000B
 
 gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleReport|FALSE|BOOLEAN|0x0000000C
 gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleLogo|FALSE|BOOLEAN|0x0000000D
+gDasharoPayloadPkgTokenSpaceGuid.PcdCapsuleRecovery|FALSE|BOOLEAN|0x0000000E

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -563,6 +563,7 @@ OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrd
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport|TRUE
   gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleReport|TRUE
   gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleLogo|TRUE
+  gDasharoPayloadPkgTokenSpaceGuid.PcdCapsuleRecovery|TRUE
 !endif
 
 [PcdsPatchableInModule.common]

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/Flashing.c
@@ -239,7 +239,9 @@ ReadCurrentFirmware (
     return NULL;
   }
 
-  Image = AllocatePool (FwSize);
+  // The buffer needs to be zero initialized so we don't get any garbage on
+  // failed reads when they are permitted.
+  Image = AllocateZeroPool (FwSize);
   if (Image == NULL) {
     DEBUG ((
       DEBUG_ERROR,

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -16,6 +16,7 @@
 #include <Library/DebugLib.h>
 #include <Library/FmpDeviceLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
 #include <Library/PopUpLib.h>
 #include <Library/PrintLib.h>
 #include <Library/SmmStoreLib.h>
@@ -25,6 +26,10 @@
 #include <PiDxe.h>
 
 #include "Flashing.h"
+
+// Number of times recovery attempts to erase and write a block before moving to
+// the next one.
+#define BLOCK_RECOVERY_ATTEMPTS  3
 
 typedef struct {
   EFI_GUID  FwGuid;
@@ -946,6 +951,131 @@ ShowBtgErrorPopup (
 }
 
 /**
+  Attempts to restore firmare to its previous state.
+
+  @param[in] OriginalImage     Firmware image to revert to.
+  @param[in] ImageSize         Size of the image in bytes.
+  @param[in] BlockSize         Size of a single block.
+  @param[in] BlockCount        Number of leading blocks to recover.
+  @param[in] DescriptorLocked  Whether IFD is locked (when locked, some ranges
+                               become read-only).
+
+  @retval TRUE   All requested blocks were reverted to their original state.
+  @retval FALSE  Recovery aborted or at least one block wasn't recovered.
+**/
+STATIC
+BOOLEAN
+AttemptRecovery (
+  IN UINT8    *OriginalImage,
+  IN UINTN    ImageSize,
+  IN UINTN    BlockSize,
+  IN UINTN    BlockCount,
+  IN BOOLEAN  DescriptorLocked
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       *CurrentImage;
+  UINTN       Offset;
+  UINTN       Block;
+  UINTN       NumBytes;
+  UINTN       Try;
+
+  if (!FixedPcdGetBool (PcdCapsuleRecovery)) {
+    DEBUG ((DEBUG_INFO, "%a(): recovery is not enabled\n", __FUNCTION__));
+    return FALSE;
+  }
+
+  CurrentImage = ReadCurrentFirmware (DescriptorLocked);
+  if (CurrentImage == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to read current firmware the first time\n",
+      __FUNCTION__
+      ));
+    return FALSE;
+  }
+
+  Offset = 0;
+  for (Block = 0; Block < BlockCount; Block++, Offset += BlockSize) {
+    //
+    // Skip blocks that didn't change.
+    //
+    if (CompareMem (CurrentImage + Offset, OriginalImage + Offset, BlockSize) == 0) {
+      continue;
+    }
+
+    //
+    // We weren't touching blocks unavailable for writing, so they should not
+    // need a recovery.  Note the use of the original image as the source of
+    // information about ranges.
+    //
+    if (DescriptorLocked && !IsRangeWriteable (OriginalImage, ImageSize, Offset, BlockSize)) {
+      continue;
+    }
+
+    //
+    // Try recovering each block more than once in case that helps.  Should do
+    // no harm other than taking more time, but it's worth a chance of avoiding
+    // bricking the system.
+    //
+    for (Try = 0; Try < BLOCK_RECOVERY_ATTEMPTS; Try++) {
+      //
+      // Unlike normal writing in FmpDeviceSetImageWithStatus(), do not stop at
+      // errors in a hope that whatever gets written is enough for having a
+      // bootable firmware.  Still, don't write blocks that weren't erased.
+      //
+      Status = SmmStoreLibEraseAnyBlock (Block);
+      if (!EFI_ERROR (Status)) {
+        NumBytes = BlockSize;
+        (VOID)SmmStoreLibWriteAnyBlock (Block, 0, &NumBytes, OriginalImage + Offset);
+        break;
+      }
+    }
+  }
+
+  FreePool (CurrentImage);
+
+  //
+  // Judge outcome of the recovery by re-reading the firmware and comparing it
+  // against the original.
+  //
+  CurrentImage = ReadCurrentFirmware (DescriptorLocked);
+  if (CurrentImage == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to read current firmware the second time\n",
+      __FUNCTION__
+      ));
+    return FALSE;
+  }
+
+  Offset = 0;
+  for (Block = 0; Block < BlockCount; Block++, Offset += BlockSize) {
+    //
+    // Blocks unavailable for writing may change contents on their own, hence
+    // they must be excluded from the comparison.
+    //
+    if (DescriptorLocked && !IsRangeWriteable (OriginalImage, ImageSize, Offset, BlockSize)) {
+      continue;
+    }
+
+    //
+    // Consider any mismatch an indication of a failed recovery.  Examining any
+    // more blocks won't change the result.
+    //
+    if (CompareMem (CurrentImage + Offset, OriginalImage + Offset, BlockSize) != 0) {
+      break;
+    }
+  }
+
+  FreePool (CurrentImage);
+
+  // Success is defined as all writable blocks within the range being equal to
+  // their initial state.
+  return Block == BlockCount;
+}
+
+/**
   Updates a firmware device with a new firmware image.  This function returns
   EFI_UNSUPPORTED if the firmware image is not updatable.  If the firmware image
   is updatable, the function should perform the following minimal validations
@@ -1175,15 +1305,35 @@ FmpDeviceSetImageWithStatus (
   return EFI_SUCCESS;
 
 IoError:
+  DEBUG ((DEBUG_ERROR, "%a(): flashing has failed at block 0x%x/0x%x\n",
+          __FUNCTION__, Block, BlockCount));
+
   //
-  // Would be nice to warn the user about potential brick state or maybe attempt
-  // a recovery.  Doesn't seem that the calling code will do any of it.
+  // Note that the recovery is performed from the start of the image and up to
+  // and including the block at which write error has occurred.  Not considering
+  // blocks that should not have changed to avoid doing any more damage if
+  // region ranges or something similar is badly messed up and could cause
+  // writing data to wrong places.
   //
+  if (AttemptRecovery (CurrentImage, ImageSize, BlockSize, Block + 1, DescriptorLocked)) {
+    DEBUG ((DEBUG_INFO, "%a(): successfully reverted to the previous firmware\n", __FUNCTION__));
+
+    Status      = EFI_ABORTED;
+    ErrorString = L"The firmware was recovered after a write failure during the update.";
+  } else {
+    DEBUG ((DEBUG_WARN, "%a(): failed to revert to the previous firmware\n", __FUNCTION__));
+
+    Status      = EFI_DEVICE_ERROR;
+    ErrorString = L"Failed to recover after a write failure.";
+  }
+
+  if (AbortReason != NULL) {
+    *AbortReason = AllocateCopyPool (StrSize (ErrorString), ErrorString);
+  }
+
   FreePool (CurrentImage);
   FreePool (UpdatedImage);
-  DEBUG ((DEBUG_ERROR, "%a(): flashing has failed at block 0x%x/0x%x: %r\n",
-          __FUNCTION__, Block, BlockCount, EFI_DEVICE_ERROR));
-  return EFI_DEVICE_ERROR;
+  return Status;
 }
 
 /**

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -38,11 +38,15 @@
   EfiVarsLib
   FmapLib
   MemoryAllocationLib
+  PcdLib
   PopUpLib
   PrintLib
   SmmStoreLib
   UefiBootServicesTableLib
   UefiRuntimeServicesTableLib
+
+[Pcd]
+  gDasharoPayloadPkgTokenSpaceGuid.PcdCapsuleRecovery  ## CONSUMES
 
 [Packages]
   CryptoPkg/CryptoPkg.dec

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
@@ -103,7 +103,7 @@ AddALine (
     return;
   }
 
-  StrCpyS (Buffer, ByteLength / 2, Line);
+  StrnCpyS (Buffer, ByteLength / 2, Line, ByteLength / 2 - 1);
 
   if (FullWidth) {
     // `- 1` because otherwise the first character gets lost.  Off-by-one error?

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
@@ -83,6 +83,8 @@ AddALine (
   IN BOOLEAN       FullWidth
   )
 {
+  UINTN   MaxByteLength;
+  UINTN   LineByteLength;
   UINTN   ByteLength;
   UINTN   Index;
   CHAR16  *Buffer;
@@ -96,7 +98,15 @@ AddALine (
     AddALine (PopUp, L"...", /*FullWidth=*/FALSE);
   }
 
-  ByteLength = FullWidth ? (PopUp->Width + 1) * 2 : StrSize (Line);
+  // `PopUp->Width - 1` here and below because actual width of the contents is
+  // one less than what's passed to CreateMultiStringPopUp().
+  MaxByteLength = (PopUp->Width - 1 + 1) * 2;
+  if (FullWidth) {
+    ByteLength = MaxByteLength;
+  } else {
+    LineByteLength = StrSize (Line);
+    ByteLength     = MIN (MaxByteLength, LineByteLength);
+  }
 
   Buffer = AllocatePool (ByteLength);
   if (Buffer == NULL) {
@@ -106,7 +116,6 @@ AddALine (
   StrnCpyS (Buffer, ByteLength / 2, Line, ByteLength / 2 - 1);
 
   if (FullWidth) {
-    // `- 1` because otherwise the first character gets lost.  Off-by-one error?
     for (Index = StrLen (Buffer); Index < PopUp->Width - 1; ++Index) {
       Buffer[Index] = L' ';
     }

--- a/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
+++ b/DasharoPayloadPkg/Library/PopUpLib/PopUpCore.c
@@ -123,6 +123,21 @@ AddALine (
   }
 
   PopUp->Lines[PopUp->Length++] = Buffer;
+
+  if (StrLen (Buffer) < StrLen (Line)) {
+    // And continuation of the line, which has the effect of wrapping long
+    // lines.
+    Line += StrLen (Buffer);
+
+    // Because leading spaces are treated specially by CreateMultiStringPopUp(),
+    // skip them when wrapping.
+    while (*Line == L' ') {
+      ++Line;
+    }
+    if (*Line != L'\0') {
+      AddALine (PopUp, Line, FullWidth);
+    }
+  }
 }
 
 STATIC

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -1379,13 +1379,13 @@ ProcessFmpCapsuleImage (
 
     if (PayloadAborted) {
       // This payload caused the failure.
-      ReportAddPayload (CapsuleResult, Status);
+      ReportAddPayload (CapsuleResult, Status, /*Message=*/NULL);
     } else if (Abort) {
       // An earlier payload caused the failure.
-      ReportAddPayload (CapsuleResult, EFI_ABORTED);
+      ReportAddPayload (CapsuleResult, EFI_ABORTED, /*Message=*/NULL);
     } else {
       // Success so far.
-      ReportAddPayload (CapsuleResult, EFI_SUCCESS);
+      ReportAddPayload (CapsuleResult, EFI_SUCCESS, /*Message=*/NULL);
     }
 
     if (HandleBuffer != NULL) {

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -948,6 +948,12 @@ GetFmpImage (
   @param[in]  Handle        A FMP handle.
   @param[in]  ImageHeader   The payload image header.
   @param[in]  PayloadIndex  The index of the payload.
+  @param[out] AbortReason   A pointer to a pointer to a Null-terminated
+                            Unicode string providing more details on an
+                            aborted operation.  The buffer is allocated with
+                            EFI_BOOT_SERVICES.AllocatePool().  It is the
+                            caller's responsibility to free this buffer with
+                            EFI_BOOT_SERVICES.FreePool().
 
   @return The status of FMP->SetImage.
 **/
@@ -955,14 +961,14 @@ EFI_STATUS
 SetFmpImageData (
   IN EFI_HANDLE                                    Handle,
   IN EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *ImageHeader,
-  IN UINTN                                         PayloadIndex
+  IN UINTN                                         PayloadIndex,
+  OUT CHAR16                                       **AbortReason
   )
 {
   EFI_STATUS                                     Status;
   EFI_FIRMWARE_MANAGEMENT_PROTOCOL               *Fmp;
   UINT8                                          *Image;
   VOID                                           *VendorCode;
-  CHAR16                                         *AbortReason;
   EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  ProgressCallback;
 
   Status = gBS->HandleProtocol (
@@ -995,7 +1001,6 @@ SetFmpImageData (
     VendorCode = Image + ImageHeader->UpdateImageSize;
   }
 
-  AbortReason = NULL;
   DEBUG ((DEBUG_INFO, "Fmp->SetImage ...\n"));
   DEBUG ((DEBUG_INFO, "ImageTypeId - %g, ", &ImageHeader->UpdateImageTypeId));
   DEBUG ((DEBUG_INFO, "PayloadIndex - 0x%x, ", PayloadIndex));
@@ -1018,6 +1023,8 @@ SetFmpImageData (
     ProgressCallback = NULL;
   }
 
+  *AbortReason = NULL;
+
   Status = Fmp->SetImage (
                   Fmp,
                   ImageHeader->UpdateImageIndex,          // ImageIndex
@@ -1025,7 +1032,7 @@ SetFmpImageData (
                   ImageHeader->UpdateImageSize,           // ImageSize
                   VendorCode,                             // VendorCode
                   ProgressCallback,                       // Progress
-                  &AbortReason                            // AbortReason
+                  AbortReason                             // AbortReason
                   );
   //
   // Set the progress bar to 100% after returning from SetImage()
@@ -1035,9 +1042,8 @@ SetFmpImageData (
   }
 
   DEBUG ((DEBUG_INFO, "Fmp->SetImage - %r\n", Status));
-  if (AbortReason != NULL) {
-    DEBUG ((DEBUG_ERROR, "%s\n", AbortReason));
-    FreePool (AbortReason);
+  if (*AbortReason != NULL) {
+    DEBUG ((DEBUG_ERROR, "Abort reason: %s\n", *AbortReason));
   }
 
   //
@@ -1242,6 +1248,7 @@ ProcessFmpCapsuleImage (
   BOOLEAN                                       NotReady;
   BOOLEAN                                       Abort;
   BOOLEAN                                       PayloadAborted;
+  CHAR16                                        *AbortReason;
 
   if (!IsFmpCapsuleGuid (&CapsuleHeader->CapsuleGuid)) {
     return ProcessFmpCapsuleImage ((EFI_CAPSULE_HEADER *)((UINTN)CapsuleHeader + CapsuleHeader->HeaderSize), CapFileName, ResetRequired, CapsuleResult);
@@ -1340,6 +1347,7 @@ ProcessFmpCapsuleImage (
     }
 
     PayloadAborted = FALSE;
+    AbortReason    = NULL;
     for (Index2 = 0; Index2 < NumberOfHandles; Index2++) {
       if (Abort) {
         RecordFmpCapsuleStatus (
@@ -1356,7 +1364,8 @@ ProcessFmpCapsuleImage (
       Status = SetFmpImageData (
                  HandleBuffer[Index2],
                  ImageHeader,
-                 Index - FmpCapsuleHeader->EmbeddedDriverCount
+                 Index - FmpCapsuleHeader->EmbeddedDriverCount,
+                 &AbortReason
                  );
       if (Status != EFI_SUCCESS) {
         Abort = TRUE;
@@ -1364,6 +1373,12 @@ ProcessFmpCapsuleImage (
       } else {
         if (ResetRequired != NULL) {
           *ResetRequired |= ResetRequiredBuffer[Index2];
+        }
+
+        // Don't assume that it's set only on errors.
+        if (AbortReason != NULL) {
+          FreePool (AbortReason);
+          AbortReason = NULL;
         }
       }
 
@@ -1379,13 +1394,17 @@ ProcessFmpCapsuleImage (
 
     if (PayloadAborted) {
       // This payload caused the failure.
-      ReportAddPayload (CapsuleResult, Status, /*Message=*/NULL);
+      ReportAddPayload (CapsuleResult, Status, AbortReason);
     } else if (Abort) {
       // An earlier payload caused the failure.
       ReportAddPayload (CapsuleResult, EFI_ABORTED, /*Message=*/NULL);
     } else {
       // Success so far.
       ReportAddPayload (CapsuleResult, EFI_SUCCESS, /*Message=*/NULL);
+    }
+
+    if (AbortReason != NULL) {
+      FreePool (AbortReason);
     }
 
     if (HandleBuffer != NULL) {

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.c
@@ -72,10 +72,21 @@ ReportFree (
   )
 {
   UINTN          CapsuleIdx;
+  UINTN          PayloadIdx;
   CapsuleResult  *Capsule;
+  PayloadResult  *Payload;
 
   for (CapsuleIdx = 0; CapsuleIdx < Report->CapsuleCount; ++CapsuleIdx) {
     Capsule = &Report->Capsules[CapsuleIdx];
+
+    for (PayloadIdx = 0; PayloadIdx < Capsule->PayloadCount; ++PayloadIdx) {
+      Payload = &Capsule->Payloads[PayloadIdx];
+
+      if (Payload->Message != NULL) {
+        FreePool (Payload->Message);
+      }
+    }
+
     if (Capsule->Payloads != NULL) {
       FreePool (Capsule->Payloads);
     }
@@ -161,7 +172,8 @@ VOID
 EFIAPI
 ReportAddPayload (
   IN OUT CapsuleResult  *Capsule OPTIONAL,
-  IN EFI_STATUS         Status
+  IN EFI_STATUS         Status,
+  IN CONST CHAR16       *Message
   )
 {
   VOID           *Payloads;
@@ -183,6 +195,14 @@ ReportAddPayload (
   PayloadResult = &Capsule->Payloads[Capsule->PayloadCount++];
 
   PayloadResult->Status = Status;
+
+  if (Message != NULL) {
+    //
+    // The field is optional and not much can be done on a failure to copy the
+    // string anyway, so not handling the error.
+    //
+    PayloadResult->Message = AllocateCopyPool (StrSize (Message), Message);
+  }
 }
 
 STATIC
@@ -508,9 +528,18 @@ ReportResults (
     for (PayloadIdx = 0; PayloadIdx < Capsule->PayloadCount; ++PayloadIdx) {
       Payload = &Capsule->Payloads[PayloadIdx];
       if (Capsule->PayloadCount > 1) {
-        AddFullLineF (PopUp, L"- Status of payload #%d: %r", PayloadIdx + 1, Payload->Status);
+        if (Payload->Message == NULL) {
+          AddFullLineF (PopUp, L"- Status of payload #%d: %r", PayloadIdx + 1, Payload->Status);
+        } else {
+          AddFullLineF (PopUp, L"- Status of payload #%d: %r (%s)",
+                        PayloadIdx + 1, Payload->Status, Payload->Message);
+        }
       } else {
-        AddFullLineF (PopUp, L"- Status of payload: %r", Payload->Status);
+        if (Payload->Message == NULL) {
+          AddFullLineF (PopUp, L"- Status of payload: %r", Payload->Status);
+        } else {
+          AddFullLineF (PopUp, L"- Status of payload: %r (%s)", Payload->Status, Payload->Message);
+        }
       }
     }
 

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.h
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/UpdateReport.h
@@ -23,6 +23,7 @@ typedef enum {
 
 typedef struct {
   EFI_STATUS  Status;
+  CHAR16      *Message;  // Optional, can be NULL.
 } PayloadResult;
 
 typedef struct {
@@ -92,7 +93,8 @@ VOID
 EFIAPI
 ReportAddPayload (
   IN OUT CapsuleResult  *Capsule OPTIONAL,
-  IN EFI_STATUS         Status
+  IN EFI_STATUS         Status,
+  IN CONST CHAR16       *Message OPTIONAL
   );
 
 VOID


### PR DESCRIPTION
* Fixed a couple bugs, see commits.
* Added wrapping long lines to `PopUpLib`.
* Added storing abort reason from an FMP capsules to update report.  It shows up in a payload status as shown below.  "the device may be unbootable" near the top still makes sense because we can't exclude this possibility (e.g., if ME region was overwritten while ME is running, returning it to its initial state doesn't necessarily mean everything is fine because by that time ME's runtime state may have changed in an incompatible way).
* During recovery each modified block is restored up to 3 times before moving on to the next one.  Recovery skips write-protected regions and part of the flash which wasn't affected by the update before hitting an error.

<img width="1512" height="1774" alt="image" src="https://github.com/user-attachments/assets/432681a4-ac95-4a2c-8b4c-b81d00fabe83" />

Elements of the following patch could be used to simulate an update failure:
```patch
 src/drivers/smmstore/store.c | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)

diff --git a/src/drivers/smmstore/store.c b/src/drivers/smmstore/store.c
index 2fca79f180..4b794c72e1 100644
--- a/src/drivers/smmstore/store.c
+++ b/src/drivers/smmstore/store.c
@@ -8,6 +8,7 @@
 #include <fmap.h>
 #include <fmap_config.h>
 #include <smmstore.h>
+#include <string.h>
 #include <types.h>
 
 #define SMMSTORE_REGION "SMMSTORE"
@@ -440,6 +441,13 @@ int smmstore_rawread_region(uint32_t block_id, uint32_t offset, uint32_t bufsize
 	if (!ptr)
 		return -1;
 
+	// Make reads return inconsistent data to "fail" recovery.
+	/* static int value; */
+	/* if (use_full_flash && block_id == 1) { */
+	/* 	memset(ptr, value++, bufsize); */
+	/* 	return 0; */
+	/* } */
+
 	printk(BIOS_DEBUG, "smm store: reading %p block %d, offset=0x%x, size=%x\n",
 	       ptr, block_id, offset, bufsize);
 
@@ -467,6 +475,10 @@ int smmstore_rawwrite_region(uint32_t block_id, uint32_t offset, uint32_t bufsiz
 	struct region_device store;
 	struct region_device com_buf;
 
+	// Simulate persistent write failure.
+	if (use_full_flash && block_id == 1)
+		return -1;
+
 	if (lookup_block_in_store(&store, block_id) < 0)
 		return -1;
 
@@ -501,6 +513,10 @@ int smmstore_rawclear_region(uint32_t block_id)
 {
 	struct region_device store;
 
+	// Simulate persistent erase failure.
+	/* if (use_full_flash && block_id == 1) */
+	/* 	return -1; */
+
 	if (lookup_block_in_store(&store, block_id) < 0)
 		return -1;
 
```

issue: https://github.com/Dasharo/dasharo-issues/issues/1435
coreboot PR: https://github.com/Dasharo/coreboot/pull/838
*ref: dsh-1128*