### PR TITLE
MdeModulePkg/BayhubSdMmcOverrideDxe: add

### DIFF
--- a/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubHost.c
+++ b/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubHost.c
@@ -8,7 +8,6 @@
 **/
 
 #include "BayhubHost.h"
-#include "SdMmcPciHcDxe.h"
 #include <Protocol/PciIo.h>
 
 /* Driver global variables*/
@@ -383,10 +382,10 @@ BhtDbgDump (
     DEBUG ((DEBUG_INFO, "HOST_CLK_DRIVE_STRENGTH: 0x%x\n", HOST_CLK_DRIVE_STRENGTH));
     DEBUG ((DEBUG_INFO, "HOST_DAT_DRIVE_STRENGTH: 0x%x\n", HOST_DAT_DRIVE_STRENGTH));
     DEBUG ((DEBUG_INFO, "Host register 0x24: 0x%08X\n", BhtMmRead32 (PciIo, SD_MMC_HC_PRESENT_STATE)));
-    DEBUG ((DEBUG_INFO, "Host register 0x28: 0x%08X\n", BhtMmRead32 (PciIo, SD_MMC_HC_HOST_CTRL1)));
+    DEBUG ((DEBUG_INFO, "Host register 0x28: 0x%08X\n", BhtMmRead32 (PciIo, 0x28)));
     DEBUG ((DEBUG_INFO, "Host register 0x2C: 0x%08X\n", BhtMmRead32 (PciIo, SD_MMC_HC_CLOCK_CTRL)));
-    DEBUG ((DEBUG_INFO, "Host register 0x30: 0x%08X\n", BhtMmRead32 (PciIo, SD_MMC_HC_NOR_INT_STS)));
-    DEBUG ((DEBUG_INFO, "Host register 0x3C: 0x%08X\n", BhtMmRead32 (PciIo, SD_MMC_HC_AUTO_CMD_ERR_STS)));
+    DEBUG ((DEBUG_INFO, "Host register 0x30: 0x%08X\n", BhtMmRead32 (PciIo, 0x30)));
+    DEBUG ((DEBUG_INFO, "Host register 0x3C: 0x%08X\n", BhtMmRead32 (PciIo, 0x3C)));
     DEBUG ((DEBUG_INFO, "Host register 0x110: 0x%08X\n", BhtMmRead32 (PciIo, 0x110)));
     DEBUG ((DEBUG_INFO, "Host register 0x114: 0x%08X\n", BhtMmRead32 (PciIo, 0x114)));
     DEBUG ((DEBUG_INFO, "Host register 0x1A8: 0x%08X\n", BhtMmRead32 (PciIo, 0x1A8)));
@@ -420,6 +419,7 @@ BhtHostInit (
 {
   UINT16      EmmcVar;
   UINT32      Value32;
+  UINT32      TmpOrData;
   EFI_STATUS  Status;
 
   if (BhtHostPciSupportType (PciIo) == EMMC_HOST) {
@@ -449,45 +449,151 @@ BhtHostInit (
   BhtPciOr32 (PciIo, 0x3E4, BIT22);
 
   // enable internal clk
-  Value32 = BIT0;
-  Status  = SdMmcHcOrMmio (PciIo, Slot, SD_MMC_HC_CLOCK_CTRL, sizeof (Value32), &Value32);
+  Value32    = BIT0;
+  Status     = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &TmpOrData);
+  TmpOrData |= Value32;
+  Status     = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint32, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &TmpOrData);
 
   // reset pll start
-  Status   = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, TRUE, sizeof (Value32), &Value32);
+  Status   = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
   Value32 |= BIT12;
-  Status   = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, FALSE, sizeof (Value32), &Value32);
+  Status   = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
   gBS->Stall (1);
 
   // reset pll end
-  Status   = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, TRUE, sizeof (Value32), &Value32);
+  Status   = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
   Value32 &= ~BIT12;
   Value32 |= BIT18;
-  Status   = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, FALSE, sizeof (Value32), &Value32);
+  Status   = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
 
   // wait BaseClk stable 0x1CC bit14
-  Status = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, TRUE, sizeof (Value32), &Value32);
+  Status = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
   while (!(Value32 & BIT14)) {
     gBS->Stall (100);
-    Status = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, TRUE, sizeof (Value32), &Value32);
+    Status = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
     DEBUG ((DEBUG_INFO, "1CC=0x%08x\n", Value32));
   }
 
   if (Value32 & BIT18) {
     // Wait 2nd Card Detect debounce Finished by wait twice of debounce max time
     while (1) {
-      Status = SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_PRESENT_STATE, TRUE, sizeof (Value32), &Value32);
+      Status = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, SD_MMC_HC_PRESENT_STATE, 1, &Value32);
       if (((Value32 >> 16) & 0x01) == ((Value32 >> 18) & 0x01)) {
         break;
       }
     }
 
     // force pll active end
-    Status   = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, TRUE, sizeof (Value32), &Value32);
+    Status   = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
     Value32 &= ~BIT18;
-    Status   = SdMmcHcRwMmio (PciIo, Slot, 0x1CC, FALSE, sizeof (Value32), &Value32);
+    Status   = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint32, Slot, 0x1CC, 1, &Value32);
   }
 
   return Status;
+}
+
+/**
+  Supply the SD clock at 400KHz for BayHub host initialization.
+
+  Programs the SDHCI Clock Control register to supply 400KHz from a
+  200MHz base clock using the 10-bit divisor format (SDHCI v3.0+).
+
+  @param[in] PciIo          The PCI IO protocol instance.
+  @param[in] Slot           The slot number (used as BAR index).
+  @param[in] ControllerVer  The host controller specification version.
+
+  @retval EFI_SUCCESS       Clock supplied successfully.
+  @retval EFI_TIMEOUT       Internal clock did not stabilise.
+  @retval Others            A PCI IO operation failed.
+
+**/
+STATIC
+EFI_STATUS
+BhtHostClockSupply (
+  IN EFI_PCI_IO_PROTOCOL  *PciIo,
+  IN UINT8                Slot,
+  IN UINT16               ControllerVer
+  )
+{
+  EFI_STATUS  Status;
+  UINT16      ClockCtrl;
+  UINT32      Divisor;
+  UINT32      SettingFreq;
+  UINT32      Remainder;
+  UINT32      StallCount;
+
+  //
+  // Stop SD clock by clearing SD Clock Enable (bit 2).
+  //
+  Status = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint16, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &ClockCtrl);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  ClockCtrl &= (UINT16) ~BIT2;
+  Status     = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint16, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &ClockCtrl);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Calculate the divisor for 400KHz from 200MHz base clock.
+  // BayHub always programs a 200MHz base clock in BhtHostInit.
+  //
+  Divisor     = 0;
+  SettingFreq = 200 * 1000;  // 200MHz in KHz units
+  while (400 < SettingFreq) {
+    Divisor++;
+    SettingFreq = (200 * 1000) / (2 * Divisor);
+    Remainder   = (200 * 1000) % (2 * Divisor);
+    if ((400 == SettingFreq) && (Remainder == 0)) {
+      break;
+    }
+
+    if ((400 == SettingFreq) && (Remainder != 0)) {
+      SettingFreq++;
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "BhtHostClockSupply: 200MHz base, divisor %d, ~%dKHz\n", Divisor, SettingFreq));
+
+  //
+  // Program divisor and enable Internal Clock.
+  // BayHub controllers implement SDHCI v3.0 which uses a 10-bit divisor:
+  //   ClockCtrl[15:8] = Divisor[7:0], ClockCtrl[7:6] = Divisor[9:8].
+  //
+  ASSERT (Divisor <= 0x3FF);
+  ClockCtrl  = (UINT16)(((Divisor & 0xFF) << 8) | ((Divisor & 0x300) >> 2));
+  ClockCtrl |= BIT0;  // Internal Clock Enable
+  Status     = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint16, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &ClockCtrl);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Wait for Internal Clock Stable (bit 1).
+  //
+  StallCount = 0;
+  do {
+    gBS->Stall (1000);
+    Status = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint16, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &ClockCtrl);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    StallCount++;
+  } while (!(ClockCtrl & BIT1) && (StallCount < 1000));
+
+  if (!(ClockCtrl & BIT1)) {
+    DEBUG ((DEBUG_ERROR, "BhtHostClockSupply: Internal Clock Stable timeout\n"));
+    return EFI_TIMEOUT;
+  }
+
+  //
+  // Enable SD Clock (bit 2).
+  //
+  ClockCtrl |= BIT2;
+  return PciIo->Mem.Write (PciIo, EfiPciIoWidthUint16, Slot, SD_MMC_HC_CLOCK_CTRL, 1, &ClockCtrl);
 }
 
 /**
@@ -507,15 +613,17 @@ BhtHostVoltageSet (
   IN  UINT8                Slot
   )
 {
-  EFI_STATUS              Status;
-  UINT8                   HostCtrl2;
-  UINT16                  ControllerVer;
-  SD_MMC_HC_PRIVATE_DATA  Private;
+  EFI_STATUS  Status;
+  UINT8       HostCtrl2;
+  UINT8       TmpCtrl2;
+  UINT16      ControllerVer;
 
   if (BhtHostPciSupportType (PciIo) == EMMC_HOST) {
     // 1.8V signaling enable
     HostCtrl2 = BIT3;
-    Status    = SdMmcHcOrMmio (PciIo, Slot, SD_MMC_HC_HOST_CTRL2, sizeof (HostCtrl2), &HostCtrl2);
+    Status    = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint8, Slot, SD_MMC_HC_HOST_CTRL2, 1, &TmpCtrl2);
+    TmpCtrl2 |= HostCtrl2;
+    Status    = PciIo->Mem.Write (PciIo, EfiPciIoWidthUint8, Slot, SD_MMC_HC_HOST_CTRL2, 1, &TmpCtrl2);
     gBS->Stall (5000);
     if (EFI_ERROR (Status)) {
       return Status;
@@ -526,15 +634,14 @@ BhtHostVoltageSet (
     gBS->Stall (10000);
   }
 
-  Status = SdMmcHcRwMmio (PciIo, Slot, SD_MMC_HC_CTRL_VER, TRUE, sizeof (ControllerVer), &ControllerVer);
+  Status = PciIo->Mem.Read (PciIo, EfiPciIoWidthUint16, Slot, SD_MMC_HC_CTRL_VER, 1, &ControllerVer);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   ControllerVer &= 0x0f;
 
-  Private.PciIo                   = PciIo;
-  Private.BaseClkFreq[Slot]       = 200;
-  Private.ControllerVersion[Slot] = ControllerVer;
-
-  Status = SdMmcHcClockSupply (&Private, Slot, 0, TRUE, 400);
+  Status = BhtHostClockSupply (PciIo, Slot, ControllerVer);
 
   return Status;
 }
@@ -643,9 +750,9 @@ BhtHostOverrideCapability (
   IN OUT  UINT32      *BaseClkFreq
   )
 {
-  EFI_STATUS           Status;
-  EFI_PCI_IO_PROTOCOL  *PciIo;
-  SD_MMC_HC_SLOT_CAP   *Cap;
+  EFI_STATUS              Status;
+  EFI_PCI_IO_PROTOCOL     *PciIo;
+  BHT_SD_MMC_HC_SLOT_CAP  *Cap;
 
   Status = gBS->HandleProtocol (
                   ControllerHandle,

--- a/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubHost.h
+++ b/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubHost.h
@@ -11,13 +11,62 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define BAYHUB_HOST_H_
 
 #include <Uefi.h>
+#include <IndustryStandard/Pci.h>
 #include <Protocol/SdMmcOverride.h>
 #include <Protocol/PciIo.h>
 #include <Library/UefiLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
-#include <Guid/DebugMask.h>
+
+//
+// SD Host Controller MMIO register offsets (SDHCI spec)
+//
+#define SD_MMC_HC_PRESENT_STATE  0x24
+#define SD_MMC_HC_HOST_CTRL2     0x3E
+#define SD_MMC_HC_CLOCK_CTRL     0x2C
+#define SD_MMC_HC_CTRL_VER       0xFE
+
+//
+// SD/MMC host controller slot capability register layout.
+// Mirrors SD_MMC_HC_SLOT_CAP from SdMmcPciHci.h; both structs must remain
+// in sync with the SDHCI Simplified Specification capability register layout.
+//
+typedef struct {
+  UINT32    TimeoutFreq   : 6; // bit 0:5
+  UINT32    Reserved      : 1; // bit 6
+  UINT32    TimeoutUnit   : 1; // bit 7
+  UINT32    BaseClkFreq   : 8; // bit 8:15
+  UINT32    MaxBlkLen     : 2; // bit 16:17
+  UINT32    BusWidth8     : 1; // bit 18
+  UINT32    Adma2         : 1; // bit 19
+  UINT32    Reserved2     : 1; // bit 20
+  UINT32    HighSpeed     : 1; // bit 21
+  UINT32    Sdma          : 1; // bit 22
+  UINT32    SuspRes       : 1; // bit 23
+  UINT32    Voltage33     : 1; // bit 24
+  UINT32    Voltage30     : 1; // bit 25
+  UINT32    Voltage18     : 1; // bit 26
+  UINT32    SysBus64V4    : 1; // bit 27
+  UINT32    SysBus64V3    : 1; // bit 28
+  UINT32    AsyncInt      : 1; // bit 29
+  UINT32    SlotType      : 2; // bit 30:31
+  UINT32    Sdr50         : 1; // bit 32
+  UINT32    Sdr104        : 1; // bit 33
+  UINT32    Ddr50         : 1; // bit 34
+  UINT32    Reserved3     : 1; // bit 35
+  UINT32    DriverTypeA   : 1; // bit 36
+  UINT32    DriverTypeC   : 1; // bit 37
+  UINT32    DriverTypeD   : 1; // bit 38
+  UINT32    DriverType4   : 1; // bit 39
+  UINT32    TimerCount    : 4; // bit 40:43
+  UINT32    Reserved4     : 1; // bit 44
+  UINT32    TuningSDR50   : 1; // bit 45
+  UINT32    RetuningMod   : 2; // bit 46:47
+  UINT32    ClkMultiplier : 8; // bit 48:55
+  UINT32    Reserved5     : 7; // bit 56:62
+  UINT32    Hs400         : 1; // bit 63
+} BHT_SD_MMC_HC_SLOT_CAP;
 
 // O2/BHT add BAR1 for PCIR mapping registers
 // These registers is defined by O2/BHT, but we may follow name definition rule.

--- a/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubSdMmcOverrideDxe.c
+++ b/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubSdMmcOverrideDxe.c
@@ -1,0 +1,53 @@
+/** @file
+  Entry point for BayHub SD/MMC Override DXE driver.
+
+  Installs EDKII_SD_MMC_OVERRIDE_PROTOCOL so that SdMmcPciHcDxe can locate it
+  via LocateProtocol and apply BayHub-specific SD/eMMC host controller
+  workarounds.
+
+  Copyright (c) 2018 - 2019, BayHub Tech inc. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Protocol/SdMmcOverride.h>
+
+#include "BayhubHost.h"
+
+/**
+  Driver entry point.  Installs the EDKII_SD_MMC_OVERRIDE_PROTOCOL instance
+  that provides BayHub-specific overrides for SdMmcPciHcDxe.
+
+  @param[in]  ImageHandle  The handle for this driver image.
+  @param[in]  SystemTable  Pointer to the EFI system table.
+
+  @retval EFI_SUCCESS  Protocol installed successfully.
+  @retval other        Protocol installation failed.
+
+**/
+EFI_STATUS
+EFIAPI
+BayhubSdMmcOverrideDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  EFI_HANDLE  Handle;
+
+  Handle = NULL;
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Handle,
+                  &gEdkiiSdMmcOverrideProtocolGuid,
+                  &BhtOverride,
+                  NULL
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  DEBUG ((DEBUG_INFO, "%a: installed BayHub SD/MMC override protocol\n", __func__));
+
+  return Status;
+}

--- a/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubSdMmcOverrideDxe.inf
+++ b/MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubSdMmcOverrideDxe.inf
@@ -1,0 +1,44 @@
+## @file
+#  DXE driver that installs EDKII_SD_MMC_OVERRIDE_PROTOCOL for BayHub SD/eMMC
+#  host controllers (vendor ID 0x1217).
+#
+#  Platform firmware that includes SdMmcPciHcDxe should also include this
+#  driver so that BayHub-specific capability overrides and initialisation
+#  hooks are applied automatically via the LocateProtocol mechanism in
+#  SdMmcPciHcDxe.
+#
+#  Copyright (c) 2018 - 2019, BayHub Tech inc. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BayhubSdMmcOverrideDxe
+  FILE_GUID                      = FB099D77-802B-47B5-B271-19AC9BE1F33D
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = BayhubSdMmcOverrideDxeEntryPoint
+
+[Sources]
+  BayhubSdMmcOverrideDxe.c
+  BayhubHost.c
+  BayhubHost.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+  DebugLib
+
+[Protocols]
+  gEdkiiSdMmcOverrideProtocolGuid               ## PRODUCES
+  gEfiPciIoProtocolGuid                         ## CONSUMES
+
+[Depex]
+  TRUE

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.c
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.c
@@ -13,7 +13,6 @@
 **/
 
 #include "SdMmcPciHcDxe.h"
-#include "BayhubHost.h"
 
 EDKII_SD_MMC_OVERRIDE  *mOverride;
 
@@ -136,8 +135,6 @@ InitializeSdMmcPciHcDxe (
              &gSdMmcPciHcComponentName2
              );
   ASSERT_EFI_ERROR (Status);
-
-  mOverride = &BhtOverride;
 
   return Status;
 }

--- a/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
+++ b/MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
@@ -41,8 +41,6 @@
   SdMmcPciHci.h
   SdMmcPciHci.c
   ComponentName.c
-  BayhubHost.c
-  BayhubHost.h
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -235,6 +235,7 @@
   MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
   MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPei.inf
   MdeModulePkg/Bus/Pci/SdMmcPciHcDxe/SdMmcPciHcDxe.inf
+  MdeModulePkg/Bus/Pci/BayhubSdMmcOverrideDxe/BayhubSdMmcOverrideDxe.inf
   MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei.inf
   MdeModulePkg/Bus/Sd/EmmcBlockIoPei/EmmcBlockIoPei.inf
   MdeModulePkg/Bus/Sd/SdBlockIoPei/SdBlockIoPei.inf


### PR DESCRIPTION
Replace the direct `mOverride = &BhtOverride` assignment in InitializeSdMmcPciHcDxe with a standalone DXE driver that installs gEdkiiSdMmcOverrideProtocolGuid, which SdMmcPciHcDxe already discovers via LocateProtocol in SdMmcPciHcDriverBindingStart.

The previous integration had two problems. First, assigning mOverride in the entry point before any DriverBindingStart call meant the LocateProtocol lookup was always skipped, making it impossible for any other platform driver to provide an alternative override. Second, BayhubHost.c depended on SdMmcPciHcDxe-internal headers and helpers (SdMmcHcOrMmio, SdMmcHcRwMmio, SdMmcHcClockSupply, SD_MMC_HC_PRIVATE_DATA), preventing it from being compiled as a separate module.

The new BayhubSdMmcOverrideDxe driver uses EFI_PCI_IO_PROTOCOL directly for all SDHCI register access and provides BhtHostClockSupply as a self-contained 400 KHz initialisation routine, removing all dependencies on SdMmcPciHcDxe internals.

SdMmcPciHcDxe is restored to its upstream state; BayhubHost sources are removed from it entirely.

Platform firmware that requires BayHub SD/eMMC support should include both SdMmcPciHcDxe.inf and BayhubSdMmcOverrideDxe.inf in its DSC.