### PR TITLE
DasharoPayloadPkg: Set Attempt Slot B flag in CMOS

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dec
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dec
@@ -17,7 +17,6 @@
 [Includes]
   Include
 
-
 [Guids]
   #
   ## Defines the token space for the UEFI Payload Package PCDs.
@@ -38,6 +37,7 @@
 
   ## GUID used for ApuConfigurationUi FormSet guid and related variables.
   gApuConfigurationFormsetGuid = {0x6f4e051b, 0x1c10, 0x422a, {0x98, 0xcf, 0x96, 0x2e, 0x78, 0x36, 0x5c, 0x74} }
+
 
 [Ppis]
   gEfiPayLoadHobBasePpiGuid = { 0xdbe23aa1, 0xa342, 0x4b97, {0x85, 0xb6, 0xb2, 0x26, 0xf1, 0x61, 0x73, 0x89} }

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -319,6 +319,7 @@
   FmapLib|DasharoPayloadPkg/Library/FmapLib/FmapLib.inf
   CbfsLib|DasharoPayloadPkg/Library/CbfsLib/CbfsLib.inf
   EfiVarsLib|DasharoPayloadPkg/Library/EfiVarsLib/EfiVarsLib.inf
+  CmosOptionsLib|DasharoPayloadPkg/Library/CmosOptionsLib/CmosOptionsLib.inf
 
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf

--- a/DasharoPayloadPkg/Include/Coreboot.h
+++ b/DasharoPayloadPkg/Include/Coreboot.h
@@ -856,4 +856,47 @@ struct tcg_efi_spec_id_event {
   /* UINT8 vendor_info[vendor_info_size]; */
 } __attribute__ ((packed));
 
+
+//
+// CMOS option table structures (coreboot cmos.layout ABI)
+//
+
+#define CB_TAG_CMOS_OPTION_TABLE   0x00c8
+
+struct cb_cmos_option_table {
+  UINT32 tag;
+  UINT32 size;           /**< Total size including all sub-records */
+  UINT32 header_length;  /**< Size of this header (without sub-records) */
+};
+
+#define CB_TAG_OPTION   0x00c9
+
+#define CMOS_MAX_NAME_LENGTH  32
+
+#define CMOS_ENTRY_TYPE_ENUM      'e'
+#define CMOS_ENTRY_TYPE_HEX       'h'
+#define CMOS_ENTRY_TYPE_RESERVED  'r'
+#define CMOS_ENTRY_TYPE_STRING    's'
+
+struct cb_cmos_entries {
+  UINT32 tag;
+  UINT32 size;
+  UINT32 bit;       /**< Starting bit position in CMOS RAM */
+  UINT32 length;    /**< Number of bits */
+  UINT32 config;    /**< Type: 'e'=enum, 'h'=hex, 'r'=reserved, 's'=string */
+  UINT32 config_id; /**< Links to cb_cmos_enums.config_id */
+  UINT8  name[CMOS_MAX_NAME_LENGTH];
+};
+
+#define CB_TAG_OPTION_CHECKSUM  0x00cc
+
+struct cb_cmos_checksum {
+  UINT32 tag;
+  UINT32 size;
+  UINT32 range_start;  /**< First bit covered by the checksum */
+  UINT32 range_end;    /**< Last bit covered by the checksum */
+  UINT32 location;     /**< Bit position where the checksum is stored */
+  UINT32 type;         /**< Checksum type (e.g. IP sum) */
+};
+
 #endif // _COREBOOT_PEI_H_INCLUDED_

--- a/DasharoPayloadPkg/Include/Library/BlParseLib.h
+++ b/DasharoPayloadPkg/Include/Library/BlParseLib.h
@@ -281,4 +281,17 @@ ParseIsDiskCapsulesBoot (
   VOID
   );
 
+/**
+  Find coreboot record with given Tag.
+
+  @param  Tag                The tag id to be found
+
+  @retval NULL              The Tag is not found.
+  @retval Others            The pointer to the record found.
+**/
+VOID *
+FindCbTag (
+  IN  UINT32  Tag
+  );
+
 #endif

--- a/DasharoPayloadPkg/Include/Library/CmosOptionsLib.h
+++ b/DasharoPayloadPkg/Include/Library/CmosOptionsLib.h
@@ -1,0 +1,255 @@
+/** @file
+  Library interface for parsing the coreboot CMOS option table and
+  accessing RTC/CMOS RAM.
+
+  The coreboot CMOS option table (CB_TAG_CMOS_OPTION_TABLE) describes the
+  layout of CMOS/RTC RAM on a given board.  This library lets callers:
+
+    - Locate the table via the coreboot table pointer passed by the bootloader.
+    - Iterate over cb_cmos_entries and cb_cmos_enums sub-records.
+    - Read and write individual option values using the hardware I/O ports.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _CMOS_OPTIONS_LIB_H_
+#define _CMOS_OPTIONS_LIB_H_
+
+#include <Uefi.h>
+#include <Coreboot.h>
+
+/**
+  Locate the coreboot CMOS option table.
+
+  Searches the coreboot table (pointed to by the bootloader parameter) for a
+  record tagged CB_TAG_CMOS_OPTION_TABLE.
+
+  @return  Pointer to struct cb_cmos_option_table, or NULL if not found.
+**/
+struct cb_cmos_option_table *
+EFIAPI
+CmosGetOptionTable (
+  VOID
+  );
+
+/**
+  Return the first sub-record with the given tag inside the CMOS option table.
+
+  Sub-records are stored immediately after the cb_cmos_option_table header
+  (at offset header_length) and traversed by the size field, exactly like
+  top-level coreboot table records.
+
+  @param[in]  CmosTable  Pointer to the CMOS option table.
+  @param[in]  Tag        Tag value to search for (CB_TAG_OPTION etc.).
+
+  @return  Pointer to the first matching sub-record, or NULL.
+**/
+struct cb_record *
+EFIAPI
+CmosFirstRecord (
+  IN struct cb_cmos_option_table  *CmosTable,
+  IN UINT32                        Tag
+  );
+
+/**
+  Return the next sub-record with the given tag after Rec.
+
+  @param[in]  CmosTable  Pointer to the CMOS option table.
+  @param[in]  Tag        Tag value to search for.
+  @param[in]  Rec        The current record; the search starts after it.
+
+  @return  Pointer to the next matching sub-record, or NULL.
+**/
+struct cb_record *
+EFIAPI
+CmosNextRecord (
+  IN struct cb_cmos_option_table  *CmosTable,
+  IN UINT32                        Tag,
+  IN struct cb_record             *Rec
+  );
+
+/**
+  Read one byte from CMOS/RTC RAM.
+
+  Addresses 0-127 are accessed via ports 0x70/0x71.
+  Addresses 128-255 are accessed via ports 0x72/0x73.
+
+  @param[in]  Address  CMOS address (0-255).
+
+  @return  The byte value at that address.
+**/
+UINT8
+EFIAPI
+CmosReadByte (
+  IN UINT16  Address
+  );
+
+/**
+  Write one byte to CMOS/RTC RAM.
+
+  @param[in]  Address  CMOS address (0-255).
+  @param[in]  Data     Value to write.
+**/
+VOID
+EFIAPI
+CmosWriteByte (
+  IN UINT16  Address,
+  IN UINT8   Data
+  );
+
+/**
+  Read the current value of a CMOS option into a UINT32.
+
+  Handles arbitrary bit positions and lengths up to 32 bits by doing
+  byte-granularity reads and assembling the result from LSB to MSB.
+
+  Reserved ('r') and string ('s') entries are not supported and return
+  EFI_UNSUPPORTED.  Options longer than 32 bits also return EFI_UNSUPPORTED.
+
+  @param[in]   Entry   cb_cmos_entries record describing the option.
+  @param[out]  Value   Receives the current value.
+
+  @retval  EFI_SUCCESS            Read successfully.
+  @retval  EFI_INVALID_PARAMETER  Entry or Value is NULL.
+  @retval  EFI_UNSUPPORTED        Reserved/string type, or length > 32.
+**/
+EFI_STATUS
+EFIAPI
+CmosReadEntry (
+  IN  struct cb_cmos_entries  *Entry,
+  OUT UINT32                  *Value
+  );
+
+/**
+  Write a value to a CMOS option.
+
+  Only the bits belonging to the option are modified; surrounding bits in
+  each affected byte are preserved with a read-modify-write sequence.
+
+  @param[in]  Entry   cb_cmos_entries record describing the option.
+  @param[in]  Value   New value (only the low Entry->length bits are used).
+
+  @retval  EFI_SUCCESS            Written successfully.
+  @retval  EFI_INVALID_PARAMETER  Entry is NULL.
+  @retval  EFI_UNSUPPORTED        Reserved/string type, or length > 32.
+**/
+EFI_STATUS
+EFIAPI
+CmosWriteEntry (
+  IN struct cb_cmos_entries  *Entry,
+  IN UINT32                   Value
+  );
+
+/**
+  Find a CMOS option entry by its ASCII name.
+
+  Scans all CB_TAG_OPTION sub-records in the CMOS option table for one whose
+  name field matches Name (case-sensitive, up to CMOS_MAX_NAME_LENGTH bytes).
+
+  @param[in]  Name  Null-terminated ASCII option name (e.g. "hyper_threading").
+
+  @return  Pointer to the matching cb_cmos_entries record, or NULL if not found
+           or if there is no CMOS option table.
+**/
+struct cb_cmos_entries *
+EFIAPI
+CmosFindEntryByName (
+  IN CONST CHAR8  *Name
+  );
+
+/**
+  Read a CMOS option value by name.
+
+  Convenience wrapper around CmosFindEntryByName() + CmosReadEntry().
+
+  @param[in]   Name   Null-terminated ASCII option name.
+  @param[out]  Value  Receives the current value.
+
+  @retval  EFI_SUCCESS            Found and read successfully.
+  @retval  EFI_NOT_FOUND          No option with that name exists.
+  @retval  EFI_INVALID_PARAMETER  Name or Value is NULL.
+  @retval  EFI_UNSUPPORTED        Option is reserved/string or longer than 32 bits.
+**/
+EFI_STATUS
+EFIAPI
+CmosReadOptionByName (
+  IN  CONST CHAR8  *Name,
+  OUT UINT32       *Value
+  );
+
+/**
+  Write a CMOS option value by name.
+
+  Convenience wrapper around CmosFindEntryByName() + CmosWriteEntry().
+
+  @param[in]  Name   Null-terminated ASCII option name.
+  @param[in]  Value  New value (high bits beyond the option's length are ignored).
+
+  @retval  EFI_SUCCESS            Found and written successfully.
+  @retval  EFI_NOT_FOUND          No option with that name exists.
+  @retval  EFI_INVALID_PARAMETER  Name is NULL.
+  @retval  EFI_UNSUPPORTED        Option is reserved/string or longer than 32 bits.
+**/
+EFI_STATUS
+EFIAPI
+CmosWriteOptionByName (
+  IN CONST CHAR8  *Name,
+  IN UINT32        Value
+  );
+
+/**
+  Compute the CMOS checksum over the range described by the coreboot checksum
+  record.
+
+  The checksum is a simple 16-bit unsigned sum of all bytes in the checksummed
+  area, truncated to 16 bits, matching the algorithm used by nvramtool.
+
+  @param[out]  Checksum  Receives the computed checksum value.
+
+  @retval  EFI_SUCCESS           Computed successfully.
+  @retval  EFI_INVALID_PARAMETER Checksum is NULL.
+  @retval  EFI_NOT_FOUND         No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED       Checksum range is not byte-aligned.
+           the range is not byte-aligned.
+**/
+EFI_STATUS
+EFIAPI
+CmosChecksumCompute (
+  UINT16 *Checksum
+  );
+
+/**
+  Write a 16-bit checksum to the CMOS checksum location.
+
+  The value is stored in big-endian byte order: high byte first.
+
+  @param[in]  Checksum  Value to write.
+
+  @retval  EFI_SUCCESS      Written successfully.
+  @retval  EFI_NOT_FOUND    No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED  Checksum location is not byte-aligned.
+**/
+EFI_STATUS
+EFIAPI
+CmosChecksumWrite (
+  IN UINT16  Checksum
+  );
+
+/**
+  Recompute the CMOS checksum and write it back to CMOS.
+
+  Convenience wrapper: calls CmosChecksumCompute() then CmosChecksumWrite().
+  This is called automatically by CmosWriteEntry() after every write.
+
+  @retval  EFI_SUCCESS      Checksum updated successfully.
+  @retval  EFI_NOT_FOUND    No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED  Checksum range or location is not byte-aligned.
+**/
+EFI_STATUS
+EFIAPI
+CmosChecksumUpdate (
+  VOID
+  );
+
+#endif // _CMOS_OPTIONS_LIB_H_

--- a/DasharoPayloadPkg/Library/CmosOptionsLib/CmosOptionsLib.c
+++ b/DasharoPayloadPkg/Library/CmosOptionsLib/CmosOptionsLib.c
@@ -1,0 +1,529 @@
+/** @file
+  CmosOptionsLib – coreboot CMOS option table parser and CMOS/RTC I/O.
+
+  Locates the CB_TAG_CMOS_OPTION_TABLE record in the coreboot table passed
+  by the bootloader, provides iterators for its sub-records, and reads/writes
+  individual option values via the standard PC RTC I/O ports.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/IoLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/CmosOptionsLib.h>
+#include <Coreboot.h>
+
+//
+// Standard PC RTC/CMOS I/O port pairs.
+// Low bank  (addresses   0-127): index 0x70, data 0x71.
+// High bank (addresses 128-255): index 0x72, data 0x73.
+//
+#define CMOS_INDEX_LOW   0x70
+#define CMOS_DATA_LOW    0x71
+#define CMOS_INDEX_HIGH  0x72
+#define CMOS_DATA_HIGH   0x73
+
+/**
+  Locate the coreboot CMOS option table.
+**/
+struct cb_cmos_option_table *
+EFIAPI
+CmosGetOptionTable (
+  VOID
+  )
+{
+  return (struct cb_cmos_option_table *)FindCbTag (CB_TAG_CMOS_OPTION_TABLE);
+}
+
+/**
+  Return the first sub-record with the given tag inside the CMOS option table.
+**/
+struct cb_record *
+EFIAPI
+CmosFirstRecord (
+  IN struct cb_cmos_option_table  *CmosTable,
+  IN UINT32                        Tag
+  )
+{
+  UINT8             *Ptr;
+  UINT8             *End;
+  struct cb_record  *Rec;
+
+  if (CmosTable == NULL) {
+    return NULL;
+  }
+
+  Ptr = (UINT8 *)CmosTable + CmosTable->header_length;
+  End = (UINT8 *)CmosTable + CmosTable->size;
+
+  while (Ptr + sizeof (struct cb_record) <= End) {
+    Rec = (struct cb_record *)Ptr;
+    if (Rec->size == 0) {
+      break;  // Corrupt table – prevent infinite loop.
+    }
+    if (Rec->tag == Tag) {
+      return Rec;
+    }
+    Ptr += Rec->size;
+  }
+
+  return NULL;
+}
+
+/**
+  Return the next sub-record with the given tag after Rec.
+**/
+struct cb_record *
+EFIAPI
+CmosNextRecord (
+  IN struct cb_cmos_option_table  *CmosTable,
+  IN UINT32                        Tag,
+  IN struct cb_record             *Rec
+  )
+{
+  UINT8             *Ptr;
+  UINT8             *End;
+  struct cb_record  *Current;
+
+  if ((CmosTable == NULL) || (Rec == NULL)) {
+    return NULL;
+  }
+
+  End = (UINT8 *)CmosTable + CmosTable->size;
+  Ptr = (UINT8 *)Rec + Rec->size;
+
+  while (Ptr + sizeof (struct cb_record) <= End) {
+    Current = (struct cb_record *)Ptr;
+    if (Current->size == 0) {
+      break;
+    }
+    if (Current->tag == Tag) {
+      return Current;
+    }
+    Ptr += Current->size;
+  }
+
+  return NULL;
+}
+
+/**
+  Read one byte from CMOS/RTC RAM.
+**/
+UINT8
+EFIAPI
+CmosReadByte (
+  IN UINT16  Address
+  )
+{
+  if (Address < 128) {
+    IoWrite8 (CMOS_INDEX_LOW, (UINT8)Address);
+    return IoRead8 (CMOS_DATA_LOW);
+  } else {
+    IoWrite8 (CMOS_INDEX_HIGH, (UINT8)Address);
+    return IoRead8 (CMOS_DATA_HIGH);
+  }
+}
+
+/**
+  Write one byte to CMOS/RTC RAM.
+**/
+VOID
+EFIAPI
+CmosWriteByte (
+  IN UINT16  Address,
+  IN UINT8   Data
+  )
+{
+  if (Address < 128) {
+    IoWrite8 (CMOS_INDEX_LOW, (UINT8)Address);
+    IoWrite8 (CMOS_DATA_LOW, Data);
+  } else {
+    IoWrite8 (CMOS_INDEX_HIGH, (UINT8)Address);
+    IoWrite8 (CMOS_DATA_HIGH, Data);
+  }
+}
+
+/**
+  Locate the CB_TAG_OPTION_CHECKSUM sub-record and return the byte positions
+  for the checksummed range and the checksum storage location.
+
+  All three positions are stored as bit offsets in the coreboot table; this
+  helper converts them to byte offsets and verifies byte alignment.
+
+  @param[out]  StartByte     First byte covered by the checksum.
+  @param[out]  EndByte       Last byte covered by the checksum (inclusive).
+  @param[out]  LocationByte  Byte address where the 16-bit checksum is stored
+                             (big-endian: high byte at LocationByte, low byte
+                             at LocationByte + 1).
+
+  @retval  EFI_SUCCESS           Information retrieved successfully.
+  @retval  EFI_NOT_FOUND         No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED       A bit position is not byte-aligned.
+**/
+STATIC
+EFI_STATUS
+CmosGetChecksumInfo (
+  OUT UINT16  *StartByte,
+  OUT UINT16  *EndByte,
+  OUT UINT16  *LocationByte
+  )
+{
+  struct cb_cmos_option_table  *CmosTable;
+  struct cb_record             *Rec;
+  struct cb_cmos_checksum      *CsumRec;
+
+  CmosTable = CmosGetOptionTable ();
+  if (CmosTable == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  Rec = CmosFirstRecord (CmosTable, CB_TAG_OPTION_CHECKSUM);
+  if (Rec == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  CsumRec = (struct cb_cmos_checksum *)Rec;
+
+  //
+  // In the coreboot table, range_start and location are the bit index of
+  // the first bit of each field, so they must be multiples of 8.
+  // range_end is the bit index of the LAST bit of the last covered byte,
+  // i.e. (last_byte * 8 + 7), so its remainder mod 8 must be 7, not 0.
+  // This matches the checks in nvramtool checksum_layout_to_bytes().
+  //
+  if ((CsumRec->range_start % 8) != 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if ((CsumRec->range_end % 8) != 7) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if ((CsumRec->location % 8) != 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  *StartByte    = (UINT16)(CsumRec->range_start / 8);
+  *EndByte      = (UINT16)(CsumRec->range_end   / 8);  // (byte*8+7)/8 == byte
+  *LocationByte = (UINT16)(CsumRec->location    / 8);
+  return EFI_SUCCESS;
+}
+
+/**
+  Compute the CMOS checksum over the range described by the coreboot checksum
+  record.
+
+  The checksum is a simple 16-bit unsigned sum of all bytes in the range,
+  truncated to 16 bits – matching the algorithm used by nvramtool.
+
+  @param[out]  Checksum  Receives the computed checksum value.
+
+  @retval  EFI_SUCCESS           Computed successfully.
+  @retval  EFI_INVALID_PARAMETER Checksum is NULL.
+  @retval  EFI_NOT_FOUND         No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED       Checksum range is not byte-aligned.
+**/
+EFI_STATUS
+EFIAPI
+CmosChecksumCompute (
+  UINT16 *Checksum
+  )
+{
+  EFI_STATUS  Status;
+  UINT16      StartByte;
+  UINT16      EndByte;
+  UINT16      LocationByte;
+  UINT16      i;
+  UINT32      Sum;
+
+  Status = CmosGetChecksumInfo (&StartByte, &EndByte, &LocationByte);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Sum = 0;
+  for (i = StartByte; i <= EndByte; i++) {
+    Sum += CmosReadByte (i);
+  }
+
+  *Checksum = Sum & 0xFFFF;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Write a 16-bit checksum to CMOS.
+
+  The checksum is stored in big-endian byte order: high byte first.
+
+  @param[in]  Checksum  Value to write.
+
+  @retval  EFI_SUCCESS      Written successfully.
+  @retval  EFI_NOT_FOUND    No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED  Checksum location is not byte-aligned.
+**/
+EFI_STATUS
+EFIAPI
+CmosChecksumWrite (
+  IN UINT16  Checksum
+  )
+{
+  EFI_STATUS  Status;
+  UINT16      StartByte;
+  UINT16      EndByte;
+  UINT16      LocationByte;
+
+  Status = CmosGetChecksumInfo (&StartByte, &EndByte, &LocationByte);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  CmosWriteByte (LocationByte,               (UINT8)(Checksum >> 8));
+  CmosWriteByte ((UINT16)(LocationByte + 1), (UINT8)(Checksum & 0x00FF));
+  return EFI_SUCCESS;
+}
+
+/**
+  Recompute the CMOS checksum and write it back to CMOS.
+
+  Convenience wrapper: calls CmosChecksumCompute() then CmosChecksumWrite().
+
+  @retval  EFI_SUCCESS      Checksum updated successfully.
+  @retval  EFI_NOT_FOUND    No CMOS option table or no checksum record.
+  @retval  EFI_UNSUPPORTED  Checksum range or location is not byte-aligned.
+**/
+EFI_STATUS
+EFIAPI
+CmosChecksumUpdate (
+  VOID
+  )
+{
+  EFI_STATUS Status;
+  UINT16     Checksum;
+
+  Status = CmosChecksumCompute(&Checksum);
+  if (EFI_ERROR(Status))
+    return Status;
+
+  return CmosChecksumWrite (Checksum);
+}
+
+/**
+  Read the current value of a CMOS option into a UINT32.
+
+  Bits are read LSB-first: entry->bit is the least-significant bit of the
+  value, stored in byte (entry->bit / 8), bit (entry->bit % 8).
+**/
+EFI_STATUS
+EFIAPI
+CmosReadEntry (
+  IN  struct cb_cmos_entries  *Entry,
+  OUT UINT32                  *Value
+  )
+{
+  UINT32  BitPos;
+  UINT32  BitsLeft;
+  UINT32  BitsRead;
+  UINT32  BitInByte;
+  UINT32  BitsFromByte;
+  UINT8   ByteVal;
+  UINT32  Result;
+
+  if ((Entry == NULL) || (Value == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Entry->config == CMOS_ENTRY_TYPE_RESERVED) ||
+      (Entry->config == CMOS_ENTRY_TYPE_STRING))
+  {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (Entry->length > 32) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Result   = 0;
+  BitPos   = Entry->bit;
+  BitsLeft = Entry->length;
+  BitsRead = 0;
+
+  while (BitsLeft > 0) {
+    BitInByte    = BitPos % 8;
+    BitsFromByte = MIN (8 - BitInByte, BitsLeft);
+
+    ByteVal  = CmosReadByte ((UINT16)(BitPos / 8));
+    ByteVal >>= BitInByte;
+    ByteVal  &= (UINT8)((1u << BitsFromByte) - 1u);
+
+    Result   |= (UINT32)ByteVal << BitsRead;
+    BitPos   += BitsFromByte;
+    BitsLeft -= BitsFromByte;
+    BitsRead += BitsFromByte;
+  }
+
+  *Value = Result;
+  return EFI_SUCCESS;
+}
+
+/**
+  Write a value to a CMOS option using read-modify-write per byte.
+**/
+EFI_STATUS
+EFIAPI
+CmosWriteEntry (
+  IN struct cb_cmos_entries  *Entry,
+  IN UINT32                   Value
+  )
+{
+  UINT32      BitPos;
+  UINT32      BitsLeft;
+  UINT32      BitInByte;
+  UINT32      BitsFromByte;
+  UINT8       Mask;
+  UINT8       ByteVal;
+  EFI_STATUS  CsumStatus;
+
+  if (Entry == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Entry->config == CMOS_ENTRY_TYPE_RESERVED) ||
+      (Entry->config == CMOS_ENTRY_TYPE_STRING))
+  {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (Entry->length > 32) {
+    return EFI_UNSUPPORTED;
+  }
+
+  BitPos   = Entry->bit;
+  BitsLeft = Entry->length;
+
+  while (BitsLeft > 0) {
+    BitInByte    = BitPos % 8;
+    BitsFromByte = MIN (8 - BitInByte, BitsLeft);
+
+    Mask    = (UINT8)(((1u << BitsFromByte) - 1u) << BitInByte);
+    ByteVal = CmosReadByte ((UINT16)(BitPos / 8));
+    ByteVal &= ~Mask;
+    ByteVal |= (UINT8)((Value & ((1u << BitsFromByte) - 1u)) << BitInByte);
+    CmosWriteByte ((UINT16)(BitPos / 8), ByteVal);
+
+    Value    >>= BitsFromByte;
+    BitPos   += BitsFromByte;
+    BitsLeft -= BitsFromByte;
+  }
+
+  //
+  // Refresh the CMOS checksum after modifying CMOS contents.  Ignore
+  // EFI_NOT_FOUND – not all coreboot builds include a checksum record.
+  //
+  CsumStatus = CmosChecksumUpdate ();
+  if (EFI_ERROR (CsumStatus) && (CsumStatus != EFI_NOT_FOUND)) {
+    return CsumStatus;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Find a CMOS option entry by its ASCII name.
+
+  Scans all CB_TAG_OPTION sub-records in the CMOS option table for one whose
+  name field matches Name (case-sensitive, up to CMOS_MAX_NAME_LENGTH bytes).
+**/
+struct cb_cmos_entries *
+EFIAPI
+CmosFindEntryByName (
+  IN CONST CHAR8  *Name
+  )
+{
+  struct cb_cmos_option_table  *CmosTable;
+  struct cb_record             *Rec;
+  struct cb_cmos_entries       *Entry;
+
+  if (Name == NULL) {
+    return NULL;
+  }
+
+  // Get the base CMOS option table
+  CmosTable = CmosGetOptionTable ();
+  if (CmosTable == NULL) {
+    return NULL;
+  }
+
+  // Iterate through all records looking for CB_TAG_OPTION
+  Rec = CmosFirstRecord (CmosTable, CB_TAG_OPTION);
+  while (Rec != NULL) {
+    Entry = (struct cb_cmos_entries *)Rec;
+
+    // Compare the option name with the requested name.
+    // Assumes Name is null-terminated and Entry->name is properly formatted.
+    if (AsciiStrnCmp ((CONST CHAR8 *)Entry->name, Name, CMOS_MAX_NAME_LENGTH) == 0) {
+      return Entry;
+    }
+
+    // Move to the next CB_TAG_OPTION record
+    Rec = CmosNextRecord (CmosTable, CB_TAG_OPTION, Rec);
+  }
+
+  return NULL;
+}
+
+/**
+  Read a CMOS option value by name.
+
+  Convenience wrapper around CmosFindEntryByName() + CmosReadEntry().
+**/
+EFI_STATUS
+EFIAPI
+CmosReadOptionByName (
+  IN  CONST CHAR8  *Name,
+  OUT UINT32       *Value
+  )
+{
+  struct cb_cmos_entries  *Entry;
+
+  if ((Name == NULL) || (Value == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Entry = CmosFindEntryByName (Name);
+  if (Entry == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  return CmosReadEntry (Entry, Value);
+}
+
+/**
+  Write a CMOS option value by name.
+
+  Convenience wrapper around CmosFindEntryByName() + CmosWriteEntry().
+**/
+EFI_STATUS
+EFIAPI
+CmosWriteOptionByName (
+  IN CONST CHAR8  *Name,
+  IN UINT32        Value
+  )
+{
+  struct cb_cmos_entries  *Entry;
+
+  if (Name == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Entry = CmosFindEntryByName (Name);
+  if (Entry == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  return CmosWriteEntry (Entry, Value);
+}

--- a/DasharoPayloadPkg/Library/CmosOptionsLib/CmosOptionsLib.inf
+++ b/DasharoPayloadPkg/Library/CmosOptionsLib/CmosOptionsLib.inf
@@ -1,0 +1,28 @@
+## @file
+#  Library for parsing the coreboot CMOS option table and accessing CMOS RAM.
+#
+#  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CmosOptionsLib
+  FILE_GUID      = 5C56D6C1-B96D-4E0F-B876-47A3F1208C4B
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = CmosOptionsLib
+
+[Sources]
+  CmosOptionsLib.c
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  BlParseLib

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -13,6 +13,7 @@
 #include <Guid/SystemResourceTable.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BlParseLib.h>
+#include <Library/CmosOptionsLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FmpDeviceLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -1033,6 +1034,7 @@ FmpDeviceSetImageWithStatus (
   UINTN       Offset;
   BOOLEAN     DescriptorLocked;
   CHAR16      *ErrorString = NULL;
+  UINT32      AttemptSlotB;
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
 
@@ -1147,6 +1149,14 @@ FmpDeviceSetImageWithStatus (
   FreePool (UpdatedImage);
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
+
+  /* Check if option for slot B exists, if so, set it */
+  Status = CmosReadOptionByName("attempt_slot_b", &AttemptSlotB);
+  if (!EFI_ERROR(Status) && !AttemptSlotB) {
+    Status = CmosWriteOptionByName("attempt_slot_b", 1);
+    if (EFI_ERROR(Status))
+      DEBUG((DEBUG_ERROR, "%a(): Failed to set Attempt Slot B flag! Status = %r\n", __FUNCTION__, Status));
+  }
 
   //
   // After the firmware on system flash was successfully updated working with

--- a/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   BaseCryptLib
   BlParseLib
+  CmosOptionsLib
   CbfsLib
   DebugLib
   EfiVarsLib


### PR DESCRIPTION
Add a library for interacting with CMOS options exposed by coreboot. Set the attempt_slot_b CMOS option after a successful capsule update.

issue: https://github.com/Dasharo/dasharo-issues/issues/1756
coreboot PR: https://github.com/Dasharo/coreboot/pull/851
*ref: prot-2030*