### PR TITLE
BaseTools/Source/Python: Add -noattr to capsule signing openssl commands

### DIFF
--- a/BaseTools/Source/Python/Capsule/GenerateCapsule.py
+++ b/BaseTools/Source/Python/Capsule/GenerateCapsule.py
@@ -182,7 +182,7 @@ def SignPayloadOpenSsl (Payload, ToolPath, SignerPrivateCertFile, OtherPublicCer
         ToolPath = ''
     Command = ''
     Command = Command + '"{Path}" '.format (Path = os.path.join (ToolPath, 'openssl'))
-    Command = Command + 'smime -sign -binary -outform DER -md {HashAlgorithm} '.format (HashAlgorithm = HashAlgorithm)
+    Command = Command + 'smime -sign -binary -noattr -outform DER -md {HashAlgorithm} '.format (HashAlgorithm = HashAlgorithm)
     Command = Command + '-signer "{Private}" -certfile "{Public}"'.format (Private = SignerPrivateCertFile, Public = OtherPublicCertFile)
     if Verbose:
         print (Command)

--- a/BaseTools/Source/Python/Pkcs7Sign/Pkcs7Sign.py
+++ b/BaseTools/Source/Python/Pkcs7Sign/Pkcs7Sign.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     #
     # Sign the input file using the specified private key and capture signature from STDOUT
     #
-    Process = subprocess.Popen('%s smime -sign -binary -signer "%s" -outform DER -md sha256 -certfile "%s"' % (OpenSslCommand, args.SignerPrivateCertFileName, args.OtherPublicCertFileName), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    Process = subprocess.Popen('%s smime -sign -binary -noattr -signer "%s" -outform DER -md sha256 -certfile "%s"' % (OpenSslCommand, args.SignerPrivateCertFileName, args.OtherPublicCertFileName), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     Signature = Process.communicate(input=FullInputFileBuffer)[0]
     if Process.returncode != 0:
       sys.exit(Process.returncode)


### PR DESCRIPTION
This makes capsule PKCS#7 signatures reproducible.

openssl smime -sign embeds a signingTime signed attribute (current UTCTime) by default. Because the attribute is inside the signed digest, the resulting RSA signature differs on every invocation even when the key and payload are identical, breaking reproducible builds of signed FMP capsules.

Pass -noattr to drop all signed attributes from the SignerInfo. The signature is then computed directly over the content, producing byte-identical output across runs.

The FMP update path is unaffected: FmpAuthenticationLibPkcs7 calls Pkcs7Verify() without extracting signed attributes, and rollback protection uses FwVersion / LowestSupportedVersion in FMP_PAYLOAD_HEADER plus the auth header MonotonicCount, not signingTime. signingTime is only consumed by DxeImageVerificationLib for Secure Boot dbt checks on PE/COFF images, which is a separate code path.

TEST=Build QEMU capsule, hash it, build again after a couple of seconds and compare hashes. The hashes are now identical:
```
m@phaaze~/D/D/coreboot> ./capsule.sh make -t keys/TestRoot.pub.pem \
                  -o keys/TestSub.pub.pem \
                  -s keys/TestCert.pem
Overwrite already existing 'emulation_qemu_q35_v0.2.1-rc1.cap'? [y/N] y
Created the capsule at 'emulation_qemu_q35_v0.2.1-rc1.cap'

m@phaaze~/D/D/coreboot> sha256sum emulation_qemu_q35_v0.2.1-rc1.cap                
0146527caf4809698752d91767f008f3b205a36ed7418130c813ebc0394ad3af  emulation_qemu_q35_v0.2.1-rc1.cap

m@phaaze~/D/D/coreboot> ./capsule.sh make -t keys/TestRoot.pub.pem \                                                                                                                                                       
                  -o keys/TestSub.pub.pem \
                  -s keys/TestCert.pem
Overwrite already existing 'emulation_qemu_q35_v0.2.1-rc1.cap'? [y/N] y
Created the capsule at 'emulation_qemu_q35_v0.2.1-rc1.cap'

m@phaaze~/D/D/coreboot> sha256sum emulation_qemu_q35_v0.2.1-rc1.cap
0146527caf4809698752d91767f008f3b205a36ed7418130c813ebc0394ad3af  emulation_qemu_q35_v0.2.1-rc1.cap
```