### PR TITLE
EC capsules

### DIFF
--- a/DasharoPayloadPkg/BlSupportDxe/BlSupportDxe.c
+++ b/DasharoPayloadPkg/BlSupportDxe/BlSupportDxe.c
@@ -281,18 +281,40 @@ BlDxeEntryPoint (
 
   Status = ParseFwInfo (&FwGuid, &FwVersion, &FwLsv, &FwSize);
   if (!EFI_ERROR (Status)) {
-    Esrt = AllocateZeroPool (sizeof (EFI_SYSTEM_RESOURCE_TABLE) + sizeof (EFI_SYSTEM_RESOURCE_ENTRY));
+    Esrt = AllocateZeroPool (sizeof (EFI_SYSTEM_RESOURCE_TABLE) + 2 * sizeof (EFI_SYSTEM_RESOURCE_ENTRY));
     ASSERT (Esrt != NULL);
 
     Esrt->FwResourceVersion  = EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION;
     Esrt->FwResourceCount    = 1;
-    Esrt->FwResourceCountMax = 1;
+    Esrt->FwResourceCountMax = 2;
 
     Esre = (EFI_SYSTEM_RESOURCE_ENTRY *)&Esrt[1];
     CopyMem (&Esre->FwClass, &FwGuid, sizeof (EFI_GUID));
     Esre->FwType                   = ESRT_FW_TYPE_SYSTEMFIRMWARE;
     Esre->FwVersion                = FwVersion;
     Esre->LowestSupportedFwVersion = FwLsv;
+
+    //
+    // Querying this information here assumes that EC information can't be
+    // provided on its own, which is most likely to always hold.
+    //
+    Status = ParseEcFwInfo (&FwGuid, &FwVersion, &FwLsv, &FwSize);
+    if (!EFI_ERROR (Status)) {
+      Esrt->FwResourceCount = 2;
+
+      CopyMem (&Esre[1].FwClass, &FwGuid, sizeof (EFI_GUID));
+      //
+      // There may be no prohibition against there being two system firmware
+      // entries (although DxeCapsuleLibFmp/UpdateReport.c looks up main
+      // firmware by type, it will work fine as long as main firmware comes
+      // first), but it may also be of no use to do that.  So even though EC can
+      // be thought of as integral part of the system, not marking it as such as
+      // nothing may depend on it anyway.
+      //
+      Esre[1].FwType                   = ESRT_FW_TYPE_DEVICEFIRMWARE;
+      Esre[1].FwVersion                = FwVersion;
+      Esre[1].LowestSupportedFwVersion = FwLsv;
+    }
 
     Status = gBS->InstallConfigurationTable (&gEfiSystemResourceTableGuid, Esrt);
     ASSERT_EFI_ERROR (Status);

--- a/DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.c
+++ b/DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.c
@@ -439,6 +439,7 @@ CapsuleSplashEntry (
   EFI_HII_HANDLE                        HiiHandle;
   EFI_GRAPHICS_OUTPUT_PROTOCOL          *GraphicsOutput;
   EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *ModeInfo;
+  CONST CHAR8                           *Message;
 
   //
   // Find GOP and ensure that pixel size is 32b.
@@ -501,11 +502,16 @@ CapsuleSplashEntry (
     }
   }
 
+  if (FixedPcdGetBool (PcdEcFirmware))
+    Message = "EC firmware update is in progress...";
+  else
+    Message = "Firmware update is in progress...";
+
   //
   // Print some warnings. Ignore the result, we still want to try printing even
   // if one of the earlier lines fails.
   //
-  Status = RenderTextCenteredAt("Firmware update is in progress...",
+  Status = RenderTextCenteredAt(Message,
                                 ModeInfo->HorizontalResolution / 2,
                                 ModeInfo->VerticalResolution * TOP_MSG_POS_PERCENT / 100);
 

--- a/DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.inf
+++ b/DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.inf
@@ -47,6 +47,7 @@
 
 [Pcd]
   gDasharoPayloadPkgTokenSpaceGuid.PcdShowCapsuleLogo  ## CONSUMES
+  gDasharoPayloadPkgTokenSpaceGuid.PcdEcFirmware       ## CONSUMES
 
 [Protocols]
   gEfiGraphicsOutputProtocolGuid       ## CONSUMES

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dec
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dec
@@ -84,6 +84,8 @@ gDasharoPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|TRUE|BOOLEAN|0x10000017
 # Useful for laptops where the PS/2 keyboard is always connected.
 # If set to TRUE, Boot Manager will unconditionally add PS keyboard to ConIn.
 gDasharoPayloadPkgTokenSpaceGuid.PcdSkipPs2Detect|FALSE|BOOLEAN|0x10000018
+## Indicates that a capsule update targets an EC.
+gDasharoPayloadPkgTokenSpaceGuid.PcdEcFirmware|FALSE|BOOLEAN|0x10000019
 
 [PcdsFixedAtBuild]
 ## Specifies the initial value for Register_A in RTC.

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dec
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dec
@@ -86,6 +86,8 @@ gDasharoPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms|TRUE|BOOLEAN|0x10000017
 gDasharoPayloadPkgTokenSpaceGuid.PcdSkipPs2Detect|FALSE|BOOLEAN|0x10000018
 ## Indicates that a capsule update targets an EC.
 gDasharoPayloadPkgTokenSpaceGuid.PcdEcFirmware|FALSE|BOOLEAN|0x10000019
+## Specifies size of EC's flash chip.
+gDasharoPayloadPkgTokenSpaceGuid.PcdEcFlashSize|0x00000000|UINT32|0x1000001a
 
 [PcdsFixedAtBuild]
 ## Specifies the initial value for Register_A in RTC.

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -885,7 +885,6 @@ OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrd
       FmpDeviceLib|UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
   }
   MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf
-  MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
   DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.inf {
     <Defines>
       FILE_GUID = E1CBE3CC-3D32-44CF-8DB9-2A78BA16F2F6

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -122,6 +122,7 @@
   DEFINE USE_UEFIVAR_BACKED_TPM_PPI     = FALSE
   DEFINE CAPSULE_SUPPORT                = FALSE
   DEFINE CAPSULE_MAIN_FW_GUID           =
+  DEFINE CAPSULE_EC_FW_GUID             =
   DEFINE CAPSULES_V2                    = FALSE
 
   DEFINE AMD_GOP_DRIVER_GUID    = 2C4CB22B-E0F8-4457-A238-576A3D0201D6
@@ -284,7 +285,6 @@
   # No need to save/restore FMP dependencies until they are utilized
   FmpDependencyDeviceLib|FmpDevicePkg/Library/FmpDependencyDeviceLibNull/FmpDependencyDeviceLibNull.inf
   FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
-  FmpDeviceLib|UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
   FmpPayloadHeaderLib|FmpDevicePkg/Library/FmpPayloadHeaderLibV1/FmpPayloadHeaderLibV1.inf
   FmpPayloadLib|FmpDevicePkg/Library/FmpPayloadLib/FmpPayloadLib.inf
   PopUpLib|DasharoPayloadPkg/Library/PopUpLib/PopUpLib.inf
@@ -881,15 +881,50 @@ OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrd
 !else
       !include DasharoPayloadPkg/CapsuleRootKey.inc
 !endif
+    <LibraryClasses>
+      FmpDeviceLib|UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
   }
   MdeModulePkg/Application/CapsuleApp/CapsuleApp.inf
   MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
   DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.inf {
+    <Defines>
+      FILE_GUID = E1CBE3CC-3D32-44CF-8DB9-2A78BA16F2F6
     <BuildOptions>
       # floats are used for image scaling
       GCC:*_*_*_CC_FLAGS = -mmmx -msse
   }
   DasharoPayloadPkg/CapsuleChargerCheckDxe/CapsuleChargerCheckDxe.inf
+!if $(CAPSULE_EC_FW_GUID) != ""
+  FmpDevicePkg/FmpDxe/FmpDxe.inf {
+    <Defines>
+      # FmpDxe interprets its FILE_GUID as firmware GUID.  This allows including
+      # multiple FmpDxe instances along each other targeting different
+      # components.
+      FILE_GUID = $(CAPSULE_EC_FW_GUID)
+    <PcdsFixedAtBuild>
+      gFmpDevicePkgTokenSpaceGuid.PcdFmpDeviceImageIdName|L"EC Firmware"
+      # Public certificate used for validation of UEFI capsules
+      #
+      # See BaseTools/Source/Python/Pkcs7Sign/Readme.md for more details on such
+      # PCDs and include files.
+!if $(CAPSULES_V2)
+      !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+!else
+      !include DasharoPayloadPkg/CapsuleRootKey.inc
+!endif
+    <LibraryClasses>
+      FmpDeviceLib|DasharoPayloadPkg/Library/FmpDeviceEcLib/FmpDeviceEcLib.inf
+  }
+  DasharoPayloadPkg/CapsuleSplashDxe/CapsuleSplashDxe.inf {
+    <Defines>
+      FILE_GUID = 8C675702-A60D-462C-B950-12F00FFDFFF3
+    <PcdsFixedAtBuild>
+      gDasharoPayloadPkgTokenSpaceGuid.PcdEcFirmware|TRUE
+    <BuildOptions>
+      # floats are used for image scaling
+      GCC:*_*_*_CC_FLAGS = -mmmx -msse
+  }
+!endif
 !if $(CAPSULES_V2)
   FmpDevicePkg/DetectTestKeyDxe/DetectTestKeyDxe.inf
   FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf

--- a/DasharoPayloadPkg/DasharoPayloadPkg.fdf
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.fdf
@@ -429,7 +429,6 @@ FILE DRIVER = CAB058DF-E938-4F85-8978-1F7E6AABDB96 {
 }
 
 !if $(CAPSULE_SUPPORT) == TRUE
-INF  MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
 !if $(CAPSULES_V2) == TRUE
 INF FmpDevicePkg/DetectTestKeyDxe/DetectTestKeyDxe.inf
 INF FmpDevicePkg/SealedCapsulesDxe/SealedCapsulesDxe.inf

--- a/DasharoPayloadPkg/Include/Coreboot.h
+++ b/DasharoPayloadPkg/Include/Coreboot.h
@@ -780,7 +780,8 @@ struct cb_range {
 	UINT32 range_size;
 } __attribute__((packed));
 
-#define CB_TAG_FW_INFO  0x0045
+#define CB_TAG_FW_INFO     0x0045
+#define CB_TAG_EC_FW_INFO  0x00a2
 
 #define CB_TAG_RB_INFO  0x0048
 

--- a/DasharoPayloadPkg/Include/Library/BlParseLib.h
+++ b/DasharoPayloadPkg/Include/Library/BlParseLib.h
@@ -254,6 +254,27 @@ ParseFwInfo (
   );
 
 /**
+  Parse EC firmware information passed in by coreboot
+
+  @param  Guid     Kind of the firmware.
+  @param  Version  Current version.
+  @param  Lsv      Lowest supported version.
+  @param  Size     Firmware size in bytes.
+
+  @retval RETURN_INVALID_PARAMETER  At least one of the parameters is NULL.
+  @retval RETURN_SUCCESS            Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND          coreboot table is missing.
+**/
+RETURN_STATUS
+EFIAPI
+ParseEcFwInfo (
+  OUT EFI_GUID  *Guid,
+  OUT UINT32    *Version,
+  OUT UINT32    *Lsv,
+  OUT UINT32    *Size
+  );
+
+/**
   Parse information in a string form identified by a number
 
   @param  Id  String identifier.

--- a/DasharoPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/DasharoPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -1245,6 +1245,48 @@ ParseBootLogo (
 /**
   Parse firmware information passed in by coreboot
 
+  @param  Tag      CBMEM tag id.
+  @param  Guid     Kind of the firmware.
+  @param  Version  Current version.
+  @param  Lsv      Lowest supported version.
+  @param  Size     Firmware size in bytes.
+
+  @retval RETURN_INVALID_PARAMETER  At least one of the parameters is NULL.
+  @retval RETURN_SUCCESS            Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND          coreboot table is missing.
+**/
+STATIC
+RETURN_STATUS
+EFIAPI
+GetFwInfo (
+  IN  UINT32    Tag,
+  OUT EFI_GUID  *Guid,
+  OUT UINT32    *Version,
+  OUT UINT32    *Lsv,
+  OUT UINT32    *Size
+  )
+{
+  struct lb_efi_fw_info  *FwInfo;
+
+  if (Guid == NULL || Version == NULL || Lsv == NULL || Size == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  FwInfo = FindCbTag (Tag);
+  if (FwInfo == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  CopyMem (Guid, &FwInfo->guid, sizeof (*Guid));
+  *Version = FwInfo->version;
+  *Lsv = FwInfo->lowest_supported_version;
+  *Size = FwInfo->fw_size;
+  return RETURN_SUCCESS;
+}
+
+/**
+  Parse firmware information passed in by coreboot
+
   @param  Guid     Kind of the firmware.
   @param  Version  Current version.
   @param  Lsv      Lowest supported version.
@@ -1263,22 +1305,31 @@ ParseFwInfo (
   OUT UINT32    *Size
   )
 {
-  struct lb_efi_fw_info  *FwInfo;
+  return GetFwInfo (CB_TAG_FW_INFO, Guid, Version, Lsv, Size);
+}
 
-  if (Guid == NULL || Version == NULL || Lsv == NULL || Size == NULL) {
-    return RETURN_INVALID_PARAMETER;
-  }
+/**
+  Parse EC firmware information passed in by coreboot
 
-  FwInfo = FindCbTag (CB_TAG_FW_INFO);
-  if (FwInfo == NULL) {
-    return RETURN_NOT_FOUND;
-  }
+  @param  Guid     Kind of the firmware.
+  @param  Version  Current version.
+  @param  Lsv      Lowest supported version.
+  @param  Size     Firmware size in bytes.
 
-  CopyMem (Guid, &FwInfo->guid, sizeof (*Guid));
-  *Version = FwInfo->version;
-  *Lsv = FwInfo->lowest_supported_version;
-  *Size = FwInfo->fw_size;
-  return RETURN_SUCCESS;
+  @retval RETURN_INVALID_PARAMETER  At least one of the parameters is NULL.
+  @retval RETURN_SUCCESS            Successfully parsed capsules.
+  @retval RETURN_NOT_FOUND          coreboot table is missing.
+**/
+RETURN_STATUS
+EFIAPI
+ParseEcFwInfo (
+  OUT EFI_GUID  *Guid,
+  OUT UINT32    *Version,
+  OUT UINT32    *Lsv,
+  OUT UINT32    *Size
+  )
+{
+  return GetFwInfo (CB_TAG_EC_FW_INFO, Guid, Version, Lsv, Size);
 }
 
 /**

--- a/DasharoPayloadPkg/Library/FmpDeviceEcLib/EcCommands.h
+++ b/DasharoPayloadPkg/Library/FmpDeviceEcLib/EcCommands.h
@@ -1,0 +1,80 @@
+/** @file
+  Provides definitions related to communication with Dasharo EC.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+
+  SPDX-License-Identifier: GPL-2.0-only
+**/
+
+#ifndef EC_COMMANDS_H__
+#define EC_COMMANDS_H__
+
+// SMFI commands
+
+// Indicates that EC is ready to accept commands
+#define CMD_NONE                    0
+// Probe for Dasharo EC protocol
+#define CMD_PROBE                   1
+// Read board string
+#define CMD_BOARD                   2
+// Read version string
+#define CMD_VERSION                 3
+// Write bytes to console
+#define CMD_PRINT                   4
+// Access SPI chip
+#define CMD_SPI                     5
+// Reset EC
+#define CMD_RESET                   6
+// Get fan speeds
+#define CMD_FAN_GET                 7
+// Set fan speeds
+#define CMD_FAN_SET                 8
+// Get keyboard map index
+#define CMD_KEYMAP_GET              9
+// Set keyboard map index
+#define CMD_KEYMAP_SET              10
+// Get LED value by index
+#define CMD_LED_GET_VALUE           11
+// Set LED value by index
+#define CMD_LED_SET_VALUE           12
+// Get LED color by index
+#define CMD_LED_GET_COLOR           13
+// Set LED color by index
+#define CMD_LED_SET_COLOR           14
+// Get LED matrix mode and speed
+#define CMD_LED_GET_MODE            15
+// Set LED matrix mode and speed
+#define CMD_LED_SET_MODE            16
+// Get key matrix state
+#define CMD_MATRIX_GET              17
+// Save LED settings to ROM
+#define CMD_LED_SAVE                18
+// Enable/disable no input mode
+#define CMD_SET_NO_INPUT            19
+// Set fan curve
+#define CMD_FAN_CURVE_SET           20
+// Get security state
+#define CMD_SECURITY_GET            21
+// Set security state
+#define CMD_SECURITY_SET            22
+// Set camera enablement
+#define CMD_CAMERA_ENABLEMENT_SET   23
+// Set WiFi + Bluetooth card enablement
+#define CMD_WIFI_BT_ENABLEMENT_SET  24
+// Get a persistent option by index
+#define CMD_OPTION_GET              25
+// Set a persistent option by index
+#define CMD_OPTION_SET              26
+
+// Flags of the SPI command (CMD_SPI)
+
+// Read from SPI chip if set, write otherwise
+#define CMD_SPI_FLAG_READ     BIT0
+// Disable SPI chip after executing command
+#define CMD_SPI_FLAG_DISABLE  BIT1
+// Run firmware from scratch RAM if necessary
+#define CMD_SPI_FLAG_SCRATCH  BIT2
+// Write to backup ROM instead
+#define CMD_SPI_FLAG_BACKUP   BIT3
+
+#endif // EC_COMMANDS_H__

--- a/DasharoPayloadPkg/Library/FmpDeviceEcLib/EcFlashing.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceEcLib/EcFlashing.c
@@ -1,0 +1,1103 @@
+/** @file
+  Provides functions for communicating with Dasharo EC.
+
+  Based on the corresponding driver in coreboot.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+
+  SPDX-License-Identifier: GPL-2.0-only
+**/
+
+#include "EcFlashing.h"
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/TimerLib.h>
+
+#include "EcCommands.h"
+
+//
+// This is the command region for Dasharo EC firmware. It must be
+// enabled for LPC in the mainboard.
+//
+#define DASHARO_EC_BASE  0x0E00
+#define DASHARO_EC_SIZE  256
+
+#define SPI_SECTOR_SIZE  1024
+
+#define REG_CMD     0
+#define REG_RESULT  1
+#define REG_DATA    2  // Start of command data
+
+// When command register is 0, command is complete
+#define CMD_FINISHED  0
+
+#define SPI_WREN       0x06  // Write Enable
+#define SPI_WRDI       0x04  // Write Disable
+#define SPI_RDSR       0x05  // Read Status Register
+#define SPI_FAST_READ  0x0b  // Read Data Bytes at Higher Speed
+#define SPI_AAI_WP     0xad  // Auto Address Increment Word Program
+#define SPI_BE         0xd7  // 1K Block Erase
+
+#define SPI_SR_WIP  (1 << 0)  // Write-in-Progress
+#define SPI_SR_WEL  (1 << 1)  // Write enable
+
+#define SPI_TIMEOUT_US  10000
+
+#define SPI_ACCESS_SIZE  252
+
+#define MAX_WRITE_RETRY  3
+
+#define EC_FLASH_SIZE  FixedPcdGet32 (PcdEcFlashSize)
+
+//
+// Weight constants for progress calculation.
+// Reading 8 blocks takes approximately the same time as 1 erase+write operation.
+//
+#define READ_SECTOR_WEIGHT   1
+#define ERASE_SECTOR_WEIGHT  4
+#define WRITE_SECTOR_WEIGHT  4
+
+typedef enum {
+  EcUpdateErrNoAc,      // AC adapter is not connected.
+  EcUpdateErrScratch,   // EC did not jump to scratch ROM
+  EcUpdateErrErase,     // EC erase failed
+  EcUpdateErrProgram,   // Programming EC failed
+} EC_UPDATE_ERROR;
+
+STATIC
+UINT8
+DasharoEcRead (
+  UINT8  Addr
+  )
+{
+  return IoRead8 (DASHARO_EC_BASE + Addr);
+}
+
+STATIC
+VOID
+DasharoEcWrite (
+  UINT8  Addr,
+  UINT8  Data
+  )
+{
+  IoWrite8 (DASHARO_EC_BASE + Addr, Data);
+}
+
+//
+// Wait for command completion with a test period of 1 microsecond.
+//
+RETURN_STATUS
+WaitForCmdFinish (
+  INTN  TimeoutUs
+  )
+{
+  while ((TimeoutUs > 0) && (DasharoEcRead (REG_CMD) != CMD_FINISHED)) {
+    MicroSecondDelay (1);
+    --TimeoutUs;
+  }
+
+	return TimeoutUs > 0 ? RETURN_SUCCESS : RETURN_TIMEOUT;
+}
+
+RETURN_STATUS
+RunCmd (
+  UINT8  Cmd
+  )
+{
+  // Write command register, which starts the command, and wait for it to finish
+  DasharoEcWrite (REG_CMD, Cmd);
+  return WaitForCmdFinish (SPI_TIMEOUT_US);
+}
+
+STATIC
+UINT8
+DasharoEcSmfiCmd (
+  UINT8  Cmd,
+  UINT8  Len,
+  UINT8  *Data
+  )
+{
+  UINTN  Index;
+
+  if (Len > DASHARO_EC_SIZE - REG_DATA) {
+    DEBUG ((DEBUG_ERROR, "%a(): Invalid command length\n", __func__));
+    return -1;
+  }
+
+  if (WaitForCmdFinish (SPI_TIMEOUT_US) != RETURN_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "%a(): Failed waiting for previous command\n", __func__));
+    return -1;
+  }
+
+  // Write data first
+  for (Index = 0; Index < Len; ++Index) {
+    DasharoEcWrite (REG_DATA + Index, Data[Index]);
+  }
+
+  if (RunCmd (Cmd) != RETURN_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "%a(): Failed waiting for a command (%d)\n", __func__, Cmd));
+    return -1;
+  }
+
+  return DasharoEcRead (REG_RESULT);
+}
+
+STATIC
+UINT8
+EcReadStr (
+  UINT8  Cmd,
+  CHAR8  *Buf,
+  UINTN  BufSize
+  )
+{
+  UINTN  Index;
+  UINT8  Result;
+  UINT8  Data;
+
+  if ((Buf == NULL) || (BufSize == 0)) {
+    return -1;
+  }
+
+  if (WaitForCmdFinish (SPI_TIMEOUT_US) != RETURN_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "%a(): Failed waiting for previous command\n", __func__));
+    return -1;
+  }
+
+  if (RunCmd (Cmd) != RETURN_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "%a(): Failed waiting for command %d\n", __func__, Cmd));
+    return -1;
+  }
+
+  Result = DasharoEcRead (REG_RESULT);
+  if (Result != 0) {
+    return Result;
+  }
+
+  for (Index = 0; Index < DASHARO_EC_SIZE - REG_DATA; Index++) {
+    Data = DasharoEcRead (REG_DATA + Index);
+
+    if (Index < BufSize) {
+      Buf[Index] = Data;
+    }
+
+    if (Data == 0) {
+      break;
+    }
+  }
+
+  Buf[BufSize - 1] = '\0';
+
+  return 0;
+}
+
+UINT8
+EFIAPI
+EcReadVersion (
+  CHAR8  *Buf,
+  UINTN  BufSize
+  )
+{
+  return EcReadStr (CMD_VERSION, Buf, BufSize);
+}
+
+// Ported from system76_ectool
+STATIC
+UINTN
+FirmwareStr (
+  CONST CHAR8  *Data,
+  UINTN        DataLen,
+  CONST CHAR8  *Key,
+  CHAR8        *Dest,
+  UINTN        DestLen
+  )
+{
+  UINTN  DataIdx;
+  UINTN  KeyIdx;
+  UINTN  RetIdx;
+  UINTN  KeyLen;
+
+  KeyLen  = AsciiStrLen (Key);
+  DataIdx = 0;
+  KeyIdx  = 0;
+  RetIdx  = 0;
+
+  // Locate the key
+  while (DataIdx < DataLen && KeyIdx < KeyLen) {
+    if (Data[DataIdx] == Key[KeyIdx]) {
+      KeyIdx += 1;
+    } else {
+      KeyIdx = 0;
+    }
+
+    DataIdx += 1;
+  }
+
+  if (KeyIdx < KeyLen) {
+    return 0;
+  }
+
+  while (DataIdx < DataLen && RetIdx < DestLen - 1 && Data[DataIdx] != 0) {
+    Dest[RetIdx++] = Data[DataIdx++];
+  }
+
+  Dest[RetIdx] = '\0';
+
+  return RetIdx;
+}
+
+// Reset the EC SPI bus
+STATIC
+UINT8
+EcSpiReset (
+  VOID
+  )
+{
+  UINT8  ResetCmd[2];
+
+  ResetCmd[0] = CMD_SPI_FLAG_DISABLE | CMD_SPI_FLAG_SCRATCH;
+  ResetCmd[1] = 0;
+
+  return DasharoEcSmfiCmd (CMD_SPI, sizeof (ResetCmd), ResetCmd);
+}
+
+//
+// Read Len bytes from EC SPI bus into Dest.
+// Returns 0 on success, <0 on error.
+//
+STATIC
+INTN
+EcSpiBusRead (
+  UINT8   *Dest,
+  UINT32  Len
+  )
+{
+  UINT32  Addr;
+  UINT32  Index;
+  UINT32  Rv;
+  UINT8   ReadCmd[2];
+
+  ReadCmd[0] = CMD_SPI_FLAG_READ | CMD_SPI_FLAG_SCRATCH;
+  ReadCmd[1] = 0;
+
+  for (Addr = 0; Addr + SPI_ACCESS_SIZE < Len; Addr += SPI_ACCESS_SIZE) {
+    ReadCmd[1] = SPI_ACCESS_SIZE;
+
+    if ((Rv = DasharoEcSmfiCmd (CMD_SPI, sizeof (ReadCmd), ReadCmd))) {
+      DEBUG ((DEBUG_ERROR, "%a(): Failed to send read SPI bus command\n", __func__));
+      return -Rv;
+    }
+
+    if (DasharoEcRead (REG_DATA + 1) != ReadCmd[1]) {
+      DEBUG ((DEBUG_ERROR, "%a(): SPI bus read insufficient bytes\n", __func__));
+      return -1;
+    }
+
+    for (Index = 0; Index < ReadCmd[1]; Index++) {
+      Dest[Addr + Index] = DasharoEcRead (REG_DATA + 2 + Index);
+    }
+  }
+
+  if (Addr == Len) {
+    return 0;
+  }
+
+  ReadCmd[1] = Len % SPI_ACCESS_SIZE;
+
+  if ((Rv = DasharoEcSmfiCmd (CMD_SPI, sizeof (ReadCmd), ReadCmd))) {
+    DEBUG ((DEBUG_ERROR, "%a(): Failed to send read SPI bus command (remainder)\n", __func__));
+    return -Rv;
+  }
+
+  if (DasharoEcRead (REG_DATA + 1) != ReadCmd[1]) {
+    DEBUG ((DEBUG_ERROR, "%a(): SPI bus read remainder insufficient bytes\n", __func__));
+    return -1;
+  }
+
+  for (Index = 0; Index < ReadCmd[1]; Index++) {
+    Dest[Addr + Index] = DasharoEcRead (REG_DATA + 2 + Index);
+  }
+
+  return 0;
+}
+
+//
+// Write Len bytes from Data to EC SPI bus with Flags.
+// Returns 0 on success, <0 on error.
+//
+STATIC
+INTN
+EcSpiBusWriteWithFlags (
+  UINT8  *Data,
+  UINT8  Len,
+  UINT8  Flags
+  )
+{
+  UINT32  Addr;
+  UINT32  Index;
+  UINT32  Rv;
+  UINT8   WriteCmd[2];
+
+  WriteCmd[0] = CMD_SPI_FLAG_SCRATCH | Flags;
+  WriteCmd[1] = 0;
+
+  for (Addr = 0; Addr + SPI_ACCESS_SIZE < Len; Addr += SPI_ACCESS_SIZE) {
+    WriteCmd[1] = SPI_ACCESS_SIZE;
+
+    for (Index = 0; Index < WriteCmd[1]; ++Index) {
+      DasharoEcWrite (REG_DATA + sizeof (WriteCmd) + Index, Data[Addr + Index]);
+    }
+
+    Rv = DasharoEcSmfiCmd (CMD_SPI, sizeof (WriteCmd), WriteCmd);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): Failed to send write SPI bus command\n", __func__));
+      return -Rv;
+    }
+
+    if (DasharoEcRead (REG_DATA + 1) != WriteCmd[1]) {
+      DEBUG ((DEBUG_ERROR, "%a(): SPI bus write insufficient bytes\n", __func__));
+      return -1;
+    }
+  }
+
+  if (Addr == Len) {
+    return 0;
+  }
+
+  WriteCmd[1] = Len % SPI_ACCESS_SIZE;
+
+  for (Index = 0; Index < WriteCmd[1]; Index++) {
+    DasharoEcWrite (REG_DATA + sizeof (WriteCmd) + Index, Data[Addr + Index]);
+  }
+
+  Rv = DasharoEcSmfiCmd (CMD_SPI, sizeof (WriteCmd), WriteCmd);
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): Failed to send write SPI bus command (remainder)\n", __func__));
+    return -Rv;
+  }
+
+  if (DasharoEcRead (REG_DATA + 1) != WriteCmd[1]) {
+    DEBUG ((DEBUG_ERROR, "%a(): SPI bus write remainder insufficient bytes\n", __func__));
+    return -1;
+  }
+
+  return 0;
+}
+
+//
+// Write Len bytes from Data to EC SPI bus.
+// Returns 0 on success, <0 on error.
+//
+STATIC
+INTN
+EcSpiBusWrite (
+  UINT8  *Data,
+  UINT8  Len
+  )
+{
+  return EcSpiBusWriteWithFlags (Data, Len, 0);
+}
+
+STATIC
+INTN
+EcSpiWaitStatus (
+  UINT8        Mask,
+  UINT8        Value,
+  CONST CHAR8  *Func,
+  UINTN        Line
+  )
+{
+  UINT64  StartTimeUs;
+  UINT64  CurrentTimeUs;
+  UINT8   Status;
+  INTN    Rv;
+  UINT8   Cmd;
+
+  Cmd = SPI_RDSR;
+
+  Rv = EcSpiReset ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReset() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiBusWrite (&Cmd, sizeof (Cmd));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWrite() failed\n", __func__));
+    return Rv;
+  }
+
+  StartTimeUs = GetTimeInNanoSecond (GetPerformanceCounter ()) / 1000;
+
+  Rv = EcSpiBusRead (&Status, sizeof (Status));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusRead() failed\n", __func__));
+    return Rv;
+  }
+
+  while ((Status & Mask) != Value) {
+    CurrentTimeUs = GetTimeInNanoSecond (GetPerformanceCounter ()) / 1000;
+    if (CurrentTimeUs - StartTimeUs >= SPI_TIMEOUT_US) {
+      DEBUG ((DEBUG_ERROR, "%a(): Timeout at %a():%u\n", __func__, Func, Line));
+      EcSpiReset ();
+      return -1;
+    }
+
+    //
+    // Status Register can be constantly read from SPI bus.
+    // No need to start new RDSR command.
+    //
+    Rv = EcSpiBusRead (&Status, sizeof (Status));
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusRead() failed\n", __func__));
+      EcSpiReset ();
+      return Rv;
+    }
+  }
+
+  Rv = EcSpiReset ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReset() failed\n", __func__));
+    return Rv;
+  }
+
+  return 0;
+}
+
+STATIC
+INTN
+EcSpiCmdWriteEnable (
+  VOID
+  )
+{
+  INTN   Rv;
+  UINT8  Cmd;
+
+  Cmd = SPI_WREN;
+
+  Rv = EcSpiWaitStatus (SPI_SR_WIP, 0, __func__, __LINE__);
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): flash not ready\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiBusWrite (&Cmd, sizeof (Cmd));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWrite() failed\n", __func__));
+    return Rv;
+  }
+
+  return EcSpiWaitStatus (SPI_SR_WIP | SPI_SR_WEL, SPI_SR_WEL, __func__, __LINE__);
+}
+
+STATIC
+INTN
+EcSpiCmdWriteDisable (
+  VOID
+  )
+{
+  INTN   Rv;
+  UINT8  Cmd;
+
+  Cmd = SPI_WRDI;
+
+  Rv = EcSpiReset ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReset() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiBusWrite (&Cmd, sizeof (Cmd));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWrite() failed\n", __func__));
+    return Rv;
+  }
+
+  return EcSpiWaitStatus (SPI_SR_WIP | SPI_SR_WEL, 0, __func__, __LINE__);
+}
+
+// Erase a sector at Addr. Returns 0 on success, <0 on error.
+STATIC
+INTN
+EcSpiEraseSector (
+  UINT32  Addr
+  )
+{
+  INTN   Rv;
+  UINT8  Buf[4];
+
+  Buf[0] = SPI_BE;
+  Buf[1] = (Addr >> 16) & 0xFF;
+  Buf[2] = (Addr >> 8) & 0xFF;
+  Buf[3] = Addr & 0xFF;
+
+  Rv = EcSpiCmdWriteEnable ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiCmdWriteEnable() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiReset ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReset() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiBusWrite (Buf, sizeof (Buf));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWrite() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiWaitStatus (SPI_SR_WIP, 0, __func__, __LINE__);
+  if (Rv) {
+    return Rv;
+  }
+
+  Rv = EcSpiCmdWriteDisable ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiCmdWriteDisable() failed\n", __func__));
+    return Rv;
+  }
+
+  return 0;
+}
+
+// Read a sector into Dest. Returns 0 on success and <0 on error.
+STATIC
+INTN
+EcSpiReadSector (
+  UINT8   *Dest,
+  UINT32  Addr
+  )
+{
+  INTN   Rv;
+  UINT8  Buf[5];
+
+  Buf[0] = SPI_FAST_READ;
+  Buf[1] = (Addr >> 16) & 0xFF;
+  Buf[2] = (Addr >> 8) & 0xFF;
+  Buf[3] = Addr & 0xFF;
+  Buf[4] = 0;
+
+  Rv = EcSpiWaitStatus (SPI_SR_WIP, 0, __func__, __LINE__);
+  if (Rv) {
+    return Rv;
+  }
+
+  Rv = EcSpiBusWrite (Buf, sizeof (Buf));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWrite() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiBusRead (Dest, SPI_SECTOR_SIZE);
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusRead() failed\n", __func__));
+    return Rv;
+  }
+
+  Rv = EcSpiReset ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReset() failed\n", __func__));
+    return Rv;
+  }
+
+  return 0;
+}
+
+// Read a sector and verify if it has been erased. Returns 0 on success and <0 on error.
+STATIC
+INTN
+EcSpiVerifyErasedSector (
+  UINT32  Addr
+  )
+{
+  INTN   Rv;
+  UINTN  Index;
+  UINT8  Buf[5];
+  UINT8  Data;
+
+  Buf[0] = SPI_FAST_READ;  // SPI Read
+  Buf[1] = (Addr >> 16) & 0xFF;
+  Buf[2] = (Addr >> 8) & 0xFF;
+  Buf[3] = Addr & 0xFF;
+  Buf[4] = 0;
+
+  Rv = EcSpiWaitStatus (SPI_SR_WIP, 0, __func__, __LINE__);
+  if (Rv) {
+    return Rv;
+  }
+
+  Rv = EcSpiBusWrite (Buf, sizeof (Buf));
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWrite() failed\n", __func__));
+    return Rv;
+  }
+
+  for (Index = 0; Index < SPI_SECTOR_SIZE; Index++) {
+    // Read the sector byte after byte and compare.
+    Rv = EcSpiBusRead (&Data, sizeof (Data));
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusRead() failed\n", __func__));
+      return Rv;
+    }
+
+    if (Data != 0xff) {
+      DEBUG ((DEBUG_ERROR, "%a(): sector at %x is not erased\n", __func__, Addr));
+      return -1;
+    }
+  }
+
+  Rv = EcSpiReset ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReset() failed\n", __func__));
+    return Rv;
+  }
+
+  return 0;
+}
+
+//
+// Program a chip with a given image at given address and size of data.
+// Returns written byte count on success and <0 on error.
+//
+STATIC
+INTN
+EcSpiWriteAt (
+  UINT32       Start,
+  CONST UINT8  *Image,
+  UINTN        Size
+  )
+{
+  INTN    Rv;
+  UINT32  Addr;
+  UINT8   Buf[6];
+
+  Buf[0] = SPI_AAI_WP;
+  Buf[1] = (Start >> 16) & 0xff;
+  Buf[2] = (Start >> 8) & 0xff;
+  Buf[3] = Start & 0xff;
+  Buf[4] = 0;
+  Buf[5] = 0;
+
+  Rv = EcSpiCmdWriteEnable ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiCmdWriteEnable() failed\n", __func__));
+    return Rv;
+  }
+
+  for (Addr = Start; Addr < Start + Size; Addr += 2) {
+    //
+    // EcSpiCmdWriteEnable ends with EcSpiWaitStatus which always calls
+    // EcSpiReset. No need to do it here again. We also reset the SPI
+    // (make the CS# go high) after AAI WP command by passing the
+    // CMD_SPI_FLAG_DISABLE to EcSpiBusWriteWithFlags.
+    //
+
+    if (Addr == Start) {
+      // 1st cmd bytes 1,2,3 are the address
+      Buf[4] = Image[Addr];
+      Buf[5] = Image[Addr + 1];
+
+      Rv = EcSpiBusWriteWithFlags (Buf, 6, CMD_SPI_FLAG_DISABLE);
+    } else {
+      Buf[1] = Image[Addr];
+      Buf[2] = Image[Addr + 1];
+
+      Rv = EcSpiBusWriteWithFlags (Buf, 3, CMD_SPI_FLAG_DISABLE);
+    }
+
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiBusWriteWithFlags() failed, addr 0x%06x\n", __func__, Addr));
+      return Rv;
+    }
+
+    //
+    // From the experiments it looked like the busy bit is never set.
+    // It is still dangerous to not probe the bit, however, AAI programming
+    // is quite picky and stops after first 2 bytes if we interrupt the
+    // process with different command than AAI word program.
+    //
+    // Rv = EcSpiWaitStatus (SPI_SR_WIP, 0, __func__, __LINE__);
+    // if (Rv) {
+    //   return Rv;
+    // }
+    //
+  }
+
+  Rv = EcSpiCmdWriteDisable ();
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiCmdWriteDisable() failed\n", __func__));
+    return Rv;
+  }
+
+  return Addr - Start;
+}
+
+//
+// Program an entire chip with a given image.
+// Returns written byte count on success and <0 on error.
+//
+STATIC
+INTN
+EcSpiImageWrite (
+  CONST UINT8          *Image,
+  UINTN                Size,
+  FW_PROGRESS_CONTROL  ProgressCtl,
+  VOID                 *ProgressContext
+  )
+{
+  UINT8   *Sector;
+  UINT32  Addr;
+  UINT32  EraseAddr;
+  UINTN   Length;
+  INTN    Rv;
+
+  Sector = AllocatePool (SPI_SECTOR_SIZE);
+  if (Sector == NULL) {
+    return -1;
+  }
+
+  Rv   = 0;
+  Addr = 0;
+
+  while ((Addr < EC_FLASH_SIZE) && (Addr + SPI_SECTOR_SIZE < Size)) {
+    Rv = EcSpiReadSector (Sector, Addr);
+    ProgressCtl (PROGRESS_INC_CURRENT, READ_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiReadSector() failed, addr 0x%06x\n", __func__, Addr));
+      goto Cleanup;
+    }
+
+    if (!CompareMem (Sector, Image + Addr, SPI_SECTOR_SIZE)) {
+      DEBUG ((DEBUG_VERBOSE, "%a(): Skipping identical sector, addr 0x%06x\n", __func__, Addr));
+      Addr += SPI_SECTOR_SIZE;
+      ProgressCtl (
+        PROGRESS_INC_CURRENT,
+        ERASE_SECTOR_WEIGHT + READ_SECTOR_WEIGHT + WRITE_SECTOR_WEIGHT,
+        ProgressContext
+        );
+      continue;
+    }
+
+    Rv = EcSpiEraseSector (Addr);
+    ProgressCtl (PROGRESS_INC_CURRENT, ERASE_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiEraseSector() failed, addr 0x%06x\n", __func__, Addr));
+      goto Cleanup;
+    }
+
+    Rv = EcSpiVerifyErasedSector (Addr);
+    ProgressCtl (PROGRESS_INC_CURRENT, READ_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiVerifyErasedSector() failed, addr 0x%06x\n", __func__, Addr));
+      goto Cleanup;
+    }
+
+    Rv = EcSpiWriteAt (Addr, Image, SPI_SECTOR_SIZE);
+    ProgressCtl (PROGRESS_INC_CURRENT, WRITE_SECTOR_WEIGHT, ProgressContext);
+    if (Rv < 0) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiWriteAt() failed, addr 0x%06x (%d)\n", __func__, Addr, Rv));
+      goto Cleanup;
+    }
+
+    Addr += SPI_SECTOR_SIZE;
+  }
+
+  // Update any remainder bytes.
+  Rv = EcSpiReadSector (Sector, Addr);
+  ProgressCtl (PROGRESS_INC_CURRENT, READ_SECTOR_WEIGHT, ProgressContext);
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReadSector() failed, last addr 0x%06x\n", __func__, Addr));
+    goto Cleanup;
+  }
+
+  // Save EraseAddr before Addr is updated.
+  EraseAddr = Addr + SPI_SECTOR_SIZE;
+
+  if (Size % SPI_SECTOR_SIZE == 0 && Addr < EC_FLASH_SIZE) {
+    Length = SPI_SECTOR_SIZE;
+  } else {
+    Length = Size % SPI_SECTOR_SIZE;
+  }
+
+  if (CompareMem (Sector, Image + Addr, Length)) {
+    Rv = EcSpiEraseSector (Addr);
+    ProgressCtl (PROGRESS_INC_CURRENT, ERASE_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiEraseSector() failed, addr 0x%06x\n", __func__, Addr));
+      goto Cleanup;
+    }
+
+    Rv = EcSpiVerifyErasedSector (Addr);
+    ProgressCtl (PROGRESS_INC_CURRENT, READ_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiVerifyErasedSector() failed, addr 0x%06x\n", __func__, Addr));
+      goto Cleanup;
+    }
+
+    Rv = EcSpiWriteAt (Addr, Image, Length);
+    ProgressCtl (PROGRESS_INC_CURRENT, WRITE_SECTOR_WEIGHT, ProgressContext);
+    if (Rv < 0) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiWriteAt() failed, addr 0x%06x (%d)\n", __func__, Addr, Rv));
+      goto Cleanup;
+    }
+
+    Addr += Length;
+  } else {
+    DEBUG ((DEBUG_VERBOSE, "%a(): Skipping identical sector, addr 0x%06x\n", __func__, Addr));
+    Addr += Length;
+  }
+
+  // Erase remaining sectors if any.
+  while (EraseAddr < EC_FLASH_SIZE) {
+    Rv = EcSpiEraseSector (EraseAddr);
+    ProgressCtl (PROGRESS_INC_CURRENT, ERASE_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiEraseSector() failed, addr 0x%06x\n", __func__, EraseAddr));
+      goto Cleanup;
+    }
+
+    EraseAddr += SPI_SECTOR_SIZE;
+  }
+
+  // If we got here, it's a success.
+  Rv = 0;
+
+Cleanup:
+  FreePool (Sector);
+
+  // Some functions return a positive value on error.
+  if (Rv > 0) {
+    Rv = -Rv;
+  }
+
+  return Rv ? Rv : Addr;
+}
+
+// Verify an image sector by sector. Returns 0 on success and <0 on error.
+STATIC
+INTN
+EcSpiImageVerify (
+  CONST UINT8          *Image,
+  UINTN                ImageSz,
+  FW_PROGRESS_CONTROL  ProgressCtl,
+  VOID                 *ProgressContext
+  )
+{
+  UINT8   *Sector;
+  UINT32  Addr;
+  INTN    Rv;
+  INTN    Error;
+
+  Sector = AllocatePool (SPI_SECTOR_SIZE);
+  if (Sector == NULL) {
+    return -1;
+  }
+
+  Rv    = 0;
+  Addr  = 0;
+  Error = 0;
+
+  while ((Addr < EC_FLASH_SIZE) && (Addr + SPI_SECTOR_SIZE < ImageSz)) {
+    Rv = EcSpiReadSector (Sector, Addr);
+    ProgressCtl (PROGRESS_INC_CURRENT, READ_SECTOR_WEIGHT, ProgressContext);
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): EcSpiReadSector() failed, addr 0x%06x\n", __func__, Addr));
+      return Rv;
+    }
+
+    Rv = CompareMem (Sector, Image + Addr, SPI_SECTOR_SIZE) ? -1 : 0;
+    if (Rv) {
+      DEBUG ((DEBUG_ERROR, "%a(): failed to verify sector, addr 0x%06x\n", __func__, Addr));
+      Error = Rv;
+    }
+
+    Addr += SPI_SECTOR_SIZE;
+  }
+
+  if (Addr == ImageSz) {
+    goto Exit;
+  }
+
+  Rv = EcSpiReadSector (Sector, Addr);
+  ProgressCtl (PROGRESS_INC_CURRENT, READ_SECTOR_WEIGHT, ProgressContext);
+  if (Rv) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcSpiReadSector() failed, last addr 0x%06x\n", __func__, Addr));
+    goto Exit;
+  }
+
+  Rv = CompareMem (Sector, Image + Addr, ImageSz % SPI_SECTOR_SIZE) ? -1 : 0;
+  if (Rv) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): failed to verify last sector, addr 0x%06x size 0x%lx\n",
+      __func__,
+      Addr,
+      ImageSz % SPI_SECTOR_SIZE
+      ));
+    goto Exit;
+  }
+
+Exit:
+  FreePool (Sector);
+
+  if (Error) {
+    return Error;
+  }
+
+  return Rv;
+}
+
+BOOLEAN
+EFIAPI
+EcImageIsValid (
+  CONST VOID  *Image,
+  UINTN       ImageSz
+  )
+{
+  CHAR8  ImgBoardStr[64];
+  CHAR8  ImgVersionStr[64];
+  CHAR8  CurBoardStr[64];
+  CHAR8  CurVersionStr[64];
+
+  // Sanity checks.
+  if (ImageSz % 2 || ImageSz > EC_FLASH_SIZE || ImageSz % SPI_SECTOR_SIZE != 0) {
+    DEBUG ((DEBUG_ERROR, "%a(): incorrect update size.\n", __func__));
+    return FALSE;
+  }
+
+  if (!FirmwareStr (Image, ImageSz, "76EC_BOARD=", ImgBoardStr, sizeof (ImgBoardStr))) {
+    DEBUG ((DEBUG_ERROR, "%a(): could not determine update target board.\n", __func__));
+    return FALSE;
+  }
+
+  if (!FirmwareStr (Image, ImageSz, "76EC_VERSION=", ImgVersionStr, sizeof (ImgVersionStr))) {
+    DEBUG ((DEBUG_ERROR, "%a(): could not determine update version.\n", __func__));
+    return FALSE;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a(): update board: %a\n", __func__, ImgBoardStr));
+  DEBUG ((DEBUG_INFO, "%a(): update version: %a\n", __func__, ImgVersionStr));
+
+  EcReadStr (CMD_BOARD, CurBoardStr, sizeof (CurBoardStr));
+  EcReadVersion (CurVersionStr, sizeof (CurVersionStr));
+
+  DEBUG ((DEBUG_INFO, "%a(): current board: %a\n", __func__, CurBoardStr));
+  DEBUG ((DEBUG_INFO, "%a(): current version: %a\n", __func__, CurVersionStr));
+
+  if (AsciiStrCmp (ImgBoardStr, CurBoardStr) != 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): update target mismatch detected! Found '%a', expected '%a'\n",
+      __func__,
+      ImgBoardStr,
+      CurBoardStr
+      ));
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+EFI_STATUS
+EFIAPI
+EcFlashImage (
+  CONST VOID           *Image,
+  UINTN                ImageSz,
+  FW_PROGRESS_CONTROL  ProgressCtl,
+  VOID                 *ProgressContext
+  )
+{
+  UINT8  SmfiCmd[2];
+  INTN   Rv;
+  UINTN  Index;
+  UINTN  SectorCount;
+
+  SmfiCmd[0] = 0;
+  SmfiCmd[1] = 0;
+
+  // An extra check just in case, shouldn't incur significant overhead.
+  if (!EcImageIsValid (Image, ImageSz)) {
+    return EFI_ABORTED;
+  }
+
+  SectorCount = (ImageSz + (SPI_SECTOR_SIZE - 1)) / SPI_SECTOR_SIZE;
+
+  //
+  // Write involves reading to skip writing sectors that don't need to be
+  // updated and then another reading later to verify erasure before writing.
+  // Flash image can be partial, the rest of the chip will be erased.
+  //
+  // Verification involves reading every sector once again.
+  //
+  ProgressCtl (
+    PROGRESS_SET_TOTAL,
+    (READ_SECTOR_WEIGHT + ERASE_SECTOR_WEIGHT + READ_SECTOR_WEIGHT + WRITE_SECTOR_WEIGHT) * SectorCount +
+    ERASE_SECTOR_WEIGHT * ((EC_FLASH_SIZE - ImageSz) / SPI_SECTOR_SIZE) +
+    READ_SECTOR_WEIGHT * SectorCount,
+    ProgressContext
+    );
+
+  // Jump to Scratch ROM.
+  SmfiCmd[0] = CMD_SPI_FLAG_SCRATCH;
+  if (DasharoEcSmfiCmd (CMD_SPI, sizeof (SmfiCmd), SmfiCmd)) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to jump to scratch ROM!\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  for (Index = 0; Index < MAX_WRITE_RETRY; Index++) {
+    Rv = EcSpiImageWrite (Image, ImageSz, ProgressCtl, ProgressContext);
+    if (Rv < 0) {
+      // EC is now in an unknown state. It may still boot from backup.
+      DEBUG ((DEBUG_ERROR, "%a(): update failed!\n", __func__));
+    } else {
+      DEBUG ((DEBUG_INFO, "%a(): wrote 0x%x bytes\n", __func__, Rv));
+    }
+
+    Rv = EcSpiImageVerify (Image, ImageSz, ProgressCtl, ProgressContext);
+    if (Rv < 0) {
+      DEBUG ((DEBUG_ERROR, "%a(): update verification failed! (try: %d)\n", __func__, Index + 1));
+    } else {
+      DEBUG ((DEBUG_INFO, "%a(): update verified.\n", __func__));
+      Rv = 0;
+      break;
+    }
+  }
+
+  if (Rv < 0) {
+    // EC is now in an unknown state. It may still boot from backup.
+    DEBUG ((DEBUG_ERROR, "%a(): update failed!\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  SmfiCmd[0] = CMD_SPI_FLAG_DISABLE;
+  if (DasharoEcSmfiCmd (CMD_SPI, sizeof (SmfiCmd), SmfiCmd)) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to disable SPI bus!\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+EcReset (
+  VOID
+  )
+{
+  UINT8  ResetCmd;
+
+  ResetCmd = 0;
+  if (DasharoEcSmfiCmd (CMD_RESET, sizeof (ResetCmd), &ResetCmd)) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to trigger reset!\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/DasharoPayloadPkg/Library/FmpDeviceEcLib/EcFlashing.h
+++ b/DasharoPayloadPkg/Library/FmpDeviceEcLib/EcFlashing.h
@@ -1,0 +1,53 @@
+/** @file
+  Provides functions for communicating with Dasharo EC.
+
+  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+
+  SPDX-License-Identifier: GPL-2.0-only
+**/
+
+#ifndef EC_FLASHING_H__
+#define EC_FLASHING_H__
+
+typedef enum {
+  PROGRESS_SET_TOTAL,
+  PROGRESS_SET_CURRENT,
+  PROGRESS_INC_CURRENT,
+} PROGRESS_OP;
+
+typedef VOID (*FW_PROGRESS_CONTROL) (
+  PROGRESS_OP  Op,
+  UINTN        Value,
+  VOID         *Context
+  );
+
+UINT8
+EFIAPI
+EcReadVersion (
+  CHAR8  *Buf,
+  UINTN  BufSize
+  );
+
+BOOLEAN
+EFIAPI
+EcImageIsValid (
+  CONST VOID  *Image,
+  UINTN       ImageSz
+  );
+
+EFI_STATUS
+EFIAPI
+EcFlashImage (
+  CONST VOID           *Image,
+  UINTN                ImageSz,
+  FW_PROGRESS_CONTROL  ProgressCtl,
+  VOID                 *ProgressContext
+  );
+
+EFI_STATUS
+EFIAPI
+EcReset (
+  VOID
+  );
+
+#endif // EC_FLASHING_H__

--- a/DasharoPayloadPkg/Library/FmpDeviceEcLib/FmpDeviceEcLib.c
+++ b/DasharoPayloadPkg/Library/FmpDeviceEcLib/FmpDeviceEcLib.c
@@ -1,0 +1,979 @@
+/** @file
+  Implements FmpDeviceLib for Dasharo EC.
+
+  Copyright (c) Microsoft Corporation.
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.
+  Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Guid/FirmwareInfoGuid.h>
+#include <Guid/SystemResourceTable.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/FmpDeviceLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Protocol/PlatformSpecificResetHandler.h>
+
+#include "EcFlashing.h"
+
+/**
+  Context structure for tracking progress during firmware update.
+**/
+typedef struct {
+  EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Callback;
+  UINTN                                          TotalUnits;
+  UINTN                                          CurrentUnits;
+  BOOLEAN                                        ShouldReport;
+} ProgressContext;
+
+//
+// Indicates that EC reset should be performed.
+//
+STATIC BOOLEAN EcResetNeeded;
+
+/**
+  This function requests firmware information on the first call, caches it and
+  returns on all calls afterwards.
+
+  @param[out] Info  Place to store a pointer to firmware information.
+
+  @retval EFI_SUCCESS            Info points to firmware information.
+  @retval EFI_INVALID_PARAMETER  Info is NULL.
+  @retval EFI_UNSUPPORTED        Configuration is inconsistent.
+**/
+STATIC
+EFI_STATUS
+GetFwInfo (
+  OUT FIRMWARE_INFO  **Info
+  )
+{
+  STATIC FIRMWARE_INFO  Storage;
+  STATIC BOOLEAN        Initialized;
+
+  EFI_STATUS  Status;
+
+  if (Info == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!Initialized) {
+    Status = ParseEcFwInfo (&Storage.Type, &Storage.Version, &Storage.LowestSupportedVersion, &Storage.ImageSize);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a(): ParseEcFwInfo() failed with: %r\n", __func__, Status));
+      return Status;
+    }
+
+    if (Storage.ImageSize > FixedPcdGet32 (PcdEcFlashSize)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a(): image size is larger than flash size: 0x%x > 0x%x\n",
+        __func__,
+        Storage.ImageSize,
+        FixedPcdGet32 (PcdEcFlashSize)
+        ));
+      return EFI_UNSUPPORTED;
+    }
+
+    EcReadVersion (Storage.VersionStr, sizeof (Storage.VersionStr));
+
+    Initialized = TRUE;
+  }
+
+  *Info = &Storage;
+  return EFI_SUCCESS;
+}
+
+/**
+  Provide a function to install the Firmware Management Protocol instance onto a
+  device handle when the device is managed by a driver that follows the UEFI
+  Driver Model.  If the device is not managed by a driver that follows the UEFI
+  Driver Model, then EFI_UNSUPPORTED is returned.
+
+  @param[in] FmpInstaller  Function that installs the Firmware Management
+                           Protocol.
+
+  @retval EFI_SUCCESS      The device is managed by a driver that follows the
+                           UEFI Driver Model.  FmpInstaller must be called on
+                           each Driver Binding Start().
+  @retval EFI_UNSUPPORTED  The device is not managed by a driver that follows
+                           the UEFI Driver Model.
+  @retval other            The Firmware Management Protocol for this firmware
+                           device is not installed.  The firmware device is
+                           still locked using FmpDeviceLock().
+**/
+EFI_STATUS
+EFIAPI
+RegisterFmpInstaller (
+  IN FMP_DEVICE_LIB_REGISTER_FMP_INSTALLER  Function
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Provide a function to uninstall the Firmware Management Protocol instance from a
+  device handle when the device is managed by a driver that follows the UEFI
+  Driver Model.  If the device is not managed by a driver that follows the UEFI
+  Driver Model, then EFI_UNSUPPORTED is returned.
+
+  @param[in] FmpUninstaller  Function that installs the Firmware Management
+                             Protocol.
+
+  @retval EFI_SUCCESS      The device is managed by a driver that follows the
+                           UEFI Driver Model.  FmpUninstaller must be called on
+                           each Driver Binding Stop().
+  @retval EFI_UNSUPPORTED  The device is not managed by a driver that follows
+                           the UEFI Driver Model.
+  @retval other            The Firmware Management Protocol for this firmware
+                           device is not installed.  The firmware device is
+                           still locked using FmpDeviceLock().
+**/
+EFI_STATUS
+EFIAPI
+RegisterFmpUninstaller (
+  IN FMP_DEVICE_LIB_REGISTER_FMP_UNINSTALLER  Function
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Set the device context for the FmpDeviceLib services when the device is
+  managed by a driver that follows the UEFI Driver Model.  If the device is not
+  managed by a driver that follows the UEFI Driver Model, then EFI_UNSUPPORTED
+  is returned.  Once a device context is set, the FmpDeviceLib services
+  operate on the currently set device context.
+
+  @param[in]      Handle   Device handle for the FmpDeviceLib services.
+                           If Handle is NULL, then Context is freed.
+  @param[in, out] Context  Device context for the FmpDeviceLib services.
+                           If Context is NULL, then a new context is allocated
+                           for Handle and the current device context is set and
+                           returned in Context.  If Context is not NULL, then
+                           the current device context is set.
+
+  @retval EFI_SUCCESS      The device is managed by a driver that follows the
+                           UEFI Driver Model.
+  @retval EFI_UNSUPPORTED  The device is not managed by a driver that follows
+                           the UEFI Driver Model.
+  @retval other            The Firmware Management Protocol for this firmware
+                           device is not installed.  The firmware device is
+                           still locked using FmpDeviceLock().
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSetContext (
+  IN EFI_HANDLE  Handle,
+  IN OUT VOID    **Context
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Returns the size, in bytes, of the firmware image currently stored in the
+  firmware device.  This function is used to by the GetImage() and
+  GetImageInfo() services of the Firmware Management Protocol.  If the image
+  size can not be determined from the firmware device, then 0 must be returned.
+
+  @param[out] Size  Pointer to the size, in bytes, of the firmware image
+                    currently stored in the firmware device.
+
+  @retval EFI_SUCCESS            The size of the firmware image currently
+                                 stored in the firmware device was returned.
+  @retval EFI_INVALID_PARAMETER  Size is NULL.
+  @retval EFI_UNSUPPORTED        The firmware device does not support reporting
+                                 the size of the currently stored firmware image.
+  @retval EFI_DEVICE_ERROR       An error occurred attempting to determine the
+                                 size of the firmware image currently stored in
+                                 in the firmware device.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetSize (
+  OUT UINTN  *Size
+  )
+{
+  EFI_STATUS     Status;
+  FIRMWARE_INFO  *FwInfo;
+
+  if (Size == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *Size = FwInfo->ImageSize;
+  }
+
+  return Status;
+}
+
+/**
+  Returns the GUID value used to fill in the ImageTypeId field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_UNSUPPORTED is returned,
+  then the ImageTypeId field is set to gEfiCallerIdGuid.  If EFI_SUCCESS is
+  returned, then ImageTypeId is set to the Guid returned from this function.
+
+  @param[out] Guid  Double pointer to a GUID value that is updated to point to
+                    to a GUID value.  The GUID value is not allocated and must
+                    not be modified or freed by the caller.
+
+  @retval EFI_SUCCESS      EFI_FIRMWARE_IMAGE_DESCRIPTOR ImageTypeId GUID is set
+                           to the returned Guid value.
+  @retval EFI_UNSUPPORTED  EFI_FIRMWARE_IMAGE_DESCRIPTOR ImageTypeId GUID is set
+                           to gEfiCallerIdGuid.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetImageTypeIdGuidPtr (
+  OUT EFI_GUID  **Guid
+  )
+{
+  EFI_STATUS     Status;
+  FIRMWARE_INFO  *FwInfo;
+
+  if (Guid == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *Guid = &FwInfo->Type;
+  }
+
+  return Status;
+}
+
+/**
+  Returns values used to fill in the AttributesSupported and AttributesSettings
+  fields of the EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the
+  GetImageInfo() service of the Firmware Management Protocol.  The following
+  bit values from the Firmware Management Protocol may be combined:
+    IMAGE_ATTRIBUTE_IMAGE_UPDATABLE
+    IMAGE_ATTRIBUTE_RESET_REQUIRED
+    IMAGE_ATTRIBUTE_AUTHENTICATION_REQUIRED
+    IMAGE_ATTRIBUTE_IN_USE
+    IMAGE_ATTRIBUTE_UEFI_IMAGE
+
+  @param[out] Supported  Attributes supported by this firmware device.
+  @param[out] Setting    Attributes settings for this firmware device.
+
+  @retval EFI_SUCCESS            The attributes supported by the firmware
+                                 device were returned.
+  @retval EFI_INVALID_PARAMETER  Supported is NULL.
+  @retval EFI_INVALID_PARAMETER  Setting is NULL.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetAttributes (
+  OUT UINT64  *Supported,
+  OUT UINT64  *Setting
+  )
+{
+  if ((Supported == NULL) || (Setting == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Supported = IMAGE_ATTRIBUTE_IMAGE_UPDATABLE |
+               IMAGE_ATTRIBUTE_RESET_REQUIRED |
+               IMAGE_ATTRIBUTE_AUTHENTICATION_REQUIRED |
+               IMAGE_ATTRIBUTE_IN_USE;
+  *Setting = *Supported;
+  return EFI_SUCCESS;
+}
+
+/**
+  Returns the value used to fill in the LowestSupportedVersion field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_SUCCESS is returned, then
+  the firmware device supports a method to report the LowestSupportedVersion
+  value from the currently stored firmware image.  If the value can not be
+  reported for the firmware image currently stored in the firmware device, then
+  EFI_UNSUPPORTED must be returned.  EFI_DEVICE_ERROR is returned if an error
+  occurs attempting to retrieve the LowestSupportedVersion value for the
+  currently stored firmware image.
+
+  @note It is recommended that all firmware devices support a method to report
+        the LowestSupportedVersion value from the currently stored firmware
+        image.
+
+  @param[out] LowestSupportedVersion  LowestSupportedVersion value retrieved
+                                      from the currently stored firmware image.
+
+  @retval EFI_SUCCESS       The lowest supported version of currently stored
+                            firmware image was returned in LowestSupportedVersion.
+  @retval EFI_UNSUPPORTED   The firmware device does not support a method to
+                            report the lowest supported version of the currently
+                            stored firmware image.
+  @retval EFI_DEVICE_ERROR  An error occurred attempting to retrieve the lowest
+                            supported version of the currently stored firmware
+                            image.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetLowestSupportedVersion (
+  OUT UINT32  *LowestSupportedVersion
+  )
+{
+  EFI_STATUS     Status;
+  FIRMWARE_INFO  *FwInfo;
+
+  if (LowestSupportedVersion == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *LowestSupportedVersion = FwInfo->LowestSupportedVersion;
+  }
+
+  return Status;
+}
+
+/**
+  Returns the Null-terminated Unicode string that is used to fill in the
+  VersionName field of the EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is
+  returned by the GetImageInfo() service of the Firmware Management Protocol.
+  The returned string must be allocated using EFI_BOOT_SERVICES.AllocatePool().
+
+  @note It is recommended that all firmware devices support a method to report
+        the VersionName string from the currently stored firmware image.
+
+  @param[out] VersionString  The version string retrieved from the currently
+                             stored firmware image.
+
+  @retval EFI_SUCCESS            The version string of currently stored
+                                 firmware image was returned in Version.
+  @retval EFI_INVALID_PARAMETER  VersionString is NULL.
+  @retval EFI_UNSUPPORTED        The firmware device does not support a method
+                                 to report the version string of the currently
+                                 stored firmware image.
+  @retval EFI_DEVICE_ERROR       An error occurred attempting to retrieve the
+                                 version string of the currently stored
+                                 firmware image.
+  @retval EFI_OUT_OF_RESOURCES   There are not enough resources to allocate the
+                                 buffer for the version string of the currently
+                                 stored firmware image.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetVersionString (
+  OUT CHAR16  **VersionString
+  )
+{
+  EFI_STATUS     Status;
+  FIRMWARE_INFO  *FwInfo;
+
+  if (VersionString == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *VersionString = AllocateCopyPool (
+                       AsciiStrSize (FwInfo->VersionStr),
+                       FwInfo->VersionStr
+                       );
+    if (*VersionString == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Returns the value used to fill in the Version field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_SUCCESS is returned, then
+  the firmware device supports a method to report the Version value from the
+  currently stored firmware image.  If the value can not be reported for the
+  firmware image currently stored in the firmware device, then EFI_UNSUPPORTED
+  must be returned.  EFI_DEVICE_ERROR is returned if an error occurs attempting
+  to retrieve the LowestSupportedVersion value for the currently stored firmware
+  image.
+
+  @note It is recommended that all firmware devices support a method to report
+        the Version value from the currently stored firmware image.
+
+  @param[out] Version  The version value retrieved from the currently stored
+                       firmware image.
+
+  @retval EFI_SUCCESS       The version of currently stored firmware image was
+                            returned in Version.
+  @retval EFI_UNSUPPORTED   The firmware device does not support a method to
+                            report the version of the currently stored firmware
+                            image.
+  @retval EFI_DEVICE_ERROR  An error occurred attempting to retrieve the version
+                            of the currently stored firmware image.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetVersion (
+  OUT UINT32  *Version
+  )
+{
+  EFI_STATUS     Status;
+  FIRMWARE_INFO  *FwInfo;
+
+  if (Version == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetFwInfo (&FwInfo);
+  if (!EFI_ERROR (Status)) {
+    *Version = FwInfo->Version;
+  }
+
+  return Status;
+}
+
+/**
+  Returns the value used to fill in the HardwareInstance field of the
+  EFI_FIRMWARE_IMAGE_DESCRIPTOR structure that is returned by the GetImageInfo()
+  service of the Firmware Management Protocol.  If EFI_SUCCESS is returned, then
+  the firmware device supports a method to report the HardwareInstance value.
+  If the value can not be reported for the firmware device, then EFI_UNSUPPORTED
+  must be returned.  EFI_DEVICE_ERROR is returned if an error occurs attempting
+  to retrieve the HardwareInstance value for the firmware device.
+
+  @param[out] HardwareInstance  The hardware instance value for the firmware
+                                device.
+
+  @retval EFI_SUCCESS       The hardware instance for the current firmware
+                            device is returned in HardwareInstance.
+  @retval EFI_UNSUPPORTED   The firmware device does not support a method to
+                            report the hardware instance value.
+  @retval EFI_DEVICE_ERROR  An error occurred attempting to retrieve the hardware
+                            instance value.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetHardwareInstance (
+  OUT UINT64  *HardwareInstance
+  )
+{
+  if (HardwareInstance == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *HardwareInstance = 0;
+  return EFI_SUCCESS;
+}
+
+/**
+  Returns a copy of the firmware image currently stored in the firmware device.
+
+  @note It is recommended that all firmware devices support a method to retrieve
+        a copy currently stored firmware image.  This can be used to support
+        features such as recovery and rollback.
+
+  @param[out]     Image     Pointer to a caller allocated buffer where the
+                            currently stored firmware image is copied to.
+  @param[in, out] ImageSize Pointer the size, in bytes, of the Image buffer.
+                            On return, points to the size, in bytes, of firmware
+                            image currently stored in the firmware device.
+
+  @retval EFI_SUCCESS            Image contains a copy of the firmware image
+                                 currently stored in the firmware device, and
+                                 ImageSize contains the size, in bytes, of the
+                                 firmware image currently stored in the
+                                 firmware device.
+  @retval EFI_BUFFER_TOO_SMALL   The buffer specified by ImageSize is too small
+                                 to hold the firmware image currently stored in
+                                 the firmware device. The buffer size required
+                                 is returned in ImageSize.
+  @retval EFI_INVALID_PARAMETER  The Image is NULL.
+  @retval EFI_INVALID_PARAMETER  The ImageSize is NULL.
+  @retval EFI_UNSUPPORTED        The operation is not supported.
+  @retval EFI_DEVICE_ERROR       An error occurred attempting to retrieve the
+                                 firmware image currently stored in the firmware
+                                 device.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceGetImage (
+  OUT    VOID   *Image,
+  IN OUT UINTN  *ImageSize
+  )
+{
+  //
+  // This seems useful only if FMP device is part of the running firmware.
+  //
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Checks if a new firmware image is valid for the firmware device.  This
+  function allows firmware update operation to validate the firmware image
+  before FmpDeviceSetImage() is called.
+
+  @param[in]  Image           Points to a new firmware image.
+  @param[in]  ImageSize       Size, in bytes, of a new firmware image.
+  @param[out] ImageUpdatable  Indicates if a new firmware image is valid for
+                              a firmware update to the firmware device.  The
+                              following values from the Firmware Management
+                              Protocol are supported:
+                                IMAGE_UPDATABLE_VALID
+                                IMAGE_UPDATABLE_INVALID
+                                IMAGE_UPDATABLE_INVALID_TYPE
+                                IMAGE_UPDATABLE_INVALID_OLD
+                                IMAGE_UPDATABLE_VALID_WITH_VENDOR_CODE
+
+  @retval EFI_SUCCESS            The image was successfully checked.  Additional
+                                 status information is returned in
+                                 ImageUpdatable.
+  @retval EFI_INVALID_PARAMETER  Image is NULL.
+  @retval EFI_INVALID_PARAMETER  ImageUpdatable is NULL.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceCheckImage (
+  IN  CONST VOID  *Image,
+  IN  UINTN       ImageSize,
+  OUT UINT32      *ImageUpdatable
+  )
+{
+  UINT32  LastAttemptStatus;
+
+  return FmpDeviceCheckImageWithStatus (Image, ImageSize, ImageUpdatable, &LastAttemptStatus);
+}
+
+/**
+  Checks if a new firmware image is valid for the firmware device.  This
+  function allows firmware update operation to validate the firmware image
+  before FmpDeviceSetImage() is called.
+
+  @param[in]  Image               Points to a new firmware image.
+  @param[in]  ImageSize           Size, in bytes, of a new firmware image.
+  @param[out] ImageUpdatable      Indicates if a new firmware image is valid for
+                                  a firmware update to the firmware device.  The
+                                  following values from the Firmware Management
+                                  Protocol are supported:
+                                    IMAGE_UPDATABLE_VALID
+                                    IMAGE_UPDATABLE_INVALID
+                                    IMAGE_UPDATABLE_INVALID_TYPE
+                                    IMAGE_UPDATABLE_INVALID_OLD
+                                    IMAGE_UPDATABLE_VALID_WITH_VENDOR_CODE
+  @param[out] LastAttemptStatus   A pointer to a UINT32 that holds the last attempt
+                                  status to report back to the ESRT table in case
+                                  of error.
+
+                                  The return status code must fall in the range of
+                                  LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MIN_ERROR_CODE_VALUE to
+                                  LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MAX_ERROR_CODE_VALUE.
+
+                                  If the value falls outside this range, it will be converted
+                                  to LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL.
+
+  @retval EFI_SUCCESS            The image was successfully checked.  Additional
+                                 status information is returned in
+                                 ImageUpdatable.
+  @retval EFI_INVALID_PARAMETER  Image is NULL.
+  @retval EFI_INVALID_PARAMETER  ImageUpdatable is NULL.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceCheckImageWithStatus (
+  IN  CONST VOID  *Image,
+  IN  UINTN       ImageSize,
+  OUT UINT32      *ImageUpdatable,
+  OUT UINT32      *LastAttemptStatus
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       FwSize;
+
+  if ((Image == NULL) || (ImageUpdatable == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
+  *ImageUpdatable    = IMAGE_UPDATABLE_INVALID;
+
+  Status = FmpDeviceGetSize (&FwSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): FmpDeviceGetSize() failed with: %r\n", __func__, Status));
+    return Status;
+  }
+
+  if (ImageSize != FwSize) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): image size (0x%x) doesn't match firmware size (0x%x)\n",
+      __func__,
+      ImageSize,
+      FwSize
+      ));
+    return EFI_ABORTED;
+  }
+
+  if (!EcImageIsValid (Image, ImageSize)) {
+    DEBUG ((DEBUG_ERROR, "%a(): EcImageIsValid() failed to validate image.\n", __func__));
+    return EFI_ABORTED;
+  }
+
+  *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
+  *ImageUpdatable    = IMAGE_UPDATABLE_VALID;
+  return EFI_SUCCESS;
+}
+
+/**
+  Updates a firmware device with a new firmware image.  This function returns
+  EFI_UNSUPPORTED if the firmware image is not updatable.  If the firmware image
+  is updatable, the function should perform the following minimal validations
+  before proceeding to do the firmware image update.
+    - Validate that the image is a supported image for this firmware device.
+      Return EFI_ABORTED if the image is not supported.  Additional details
+      on why the image is not a supported image may be returned in AbortReason.
+    - Validate the data from VendorCode if is not NULL.  Firmware image
+      validation must be performed before VendorCode data validation.
+      VendorCode data is ignored or considered invalid if image validation
+      fails.  Return EFI_ABORTED if the VendorCode data is invalid.
+
+  VendorCode enables vendor to implement vendor-specific firmware image update
+  policy.  Null if the caller did not specify the policy or use the default
+  policy.  As an example, vendor can implement a policy to allow an option to
+  force a firmware image update when the abort reason is due to the new firmware
+  image version is older than the current firmware image version or bad image
+  checksum.  Sensitive operations such as those wiping the entire firmware image
+  and render the device to be non-functional should be encoded in the image
+  itself rather than passed with the VendorCode.  AbortReason enables vendor to
+  have the option to provide a more detailed description of the abort reason to
+  the caller.
+
+  @param[in]  Image             Points to the new firmware image.
+  @param[in]  ImageSize         Size, in bytes, of the new firmware image.
+  @param[in]  VendorCode        This enables vendor to implement vendor-specific
+                                firmware image update policy.  NULL indicates
+                                the caller did not specify the policy or use the
+                                default policy.
+  @param[in]  Progress          A function used to report the progress of
+                                updating the firmware device with the new
+                                firmware image.
+  @param[in]  CapsuleFwVersion  The version of the new firmware image from the
+                                update capsule that provided the new firmware
+                                image.
+  @param[out] AbortReason       A pointer to a pointer to a Null-terminated
+                                Unicode string providing more details on an
+                                aborted operation. The buffer is allocated by
+                                this function with
+                                EFI_BOOT_SERVICES.AllocatePool().  It is the
+                                caller's responsibility to free this buffer with
+                                EFI_BOOT_SERVICES.FreePool().
+
+  @retval EFI_SUCCESS            The firmware device was successfully updated
+                                 with the new firmware image.
+  @retval EFI_ABORTED            The operation is aborted.  Additional details
+                                 are provided in AbortReason.
+  @retval EFI_INVALID_PARAMETER  The Image was NULL.
+  @retval EFI_UNSUPPORTED        The operation is not supported.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSetImage (
+  IN  CONST VOID                                     *Image,
+  IN  UINTN                                          ImageSize,
+  IN  CONST VOID                                     *VendorCode        OPTIONAL,
+  IN  EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Progress           OPTIONAL,
+  IN  UINT32                                         CapsuleFwVersion,
+  OUT CHAR16                                         **AbortReason
+  )
+{
+  UINT32  LastAttemptStatus;
+
+  return FmpDeviceSetImageWithStatus (
+           Image,
+           ImageSize,
+           VendorCode,
+           Progress,
+           CapsuleFwVersion,
+           AbortReason,
+           &LastAttemptStatus
+           );
+}
+
+/**
+  Reports current progress as a percentage.
+
+  @param[in, out] Ctx  Progress context to update and report from.
+**/
+STATIC
+VOID
+ReportProgress (
+  IN OUT ProgressContext  *Ctx
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Progress;
+
+  if (!Ctx->ShouldReport || Ctx->Callback == NULL) {
+    Ctx->ShouldReport = FALSE;
+    return;
+  }
+
+  if (Ctx->TotalUnits == 0) {
+    return;
+  }
+
+  Progress = (Ctx->CurrentUnits * 100) / Ctx->TotalUnits;
+
+  //
+  // Value of 0 means "progress reporting is not supported", so avoid using it.
+  //
+  if (Progress == 0) {
+    Progress = 1;
+  }
+
+  //
+  // Cap at 100%
+  //
+  if (Progress > 100) {
+    Progress = 100;
+  }
+
+  Status = Ctx->Callback (Progress);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "%a(): progress callback failed with: %r\n", __func__, Status));
+    Ctx->ShouldReport = FALSE;
+  }
+}
+
+STATIC
+VOID
+UpdateProgress (
+  IN PROGRESS_OP  Op,
+  IN UINTN        Value,
+  IN VOID         *Context
+  )
+{
+  ProgressContext  *Ctx;
+
+  Ctx = Context;
+
+  switch (Op) {
+    case PROGRESS_SET_TOTAL:
+      Ctx->TotalUnits = Value;
+      break;
+    case PROGRESS_SET_CURRENT:
+      Ctx->CurrentUnits = Value;
+      break;
+    case PROGRESS_INC_CURRENT:
+      Ctx->CurrentUnits += Value;
+      break;
+  }
+
+  ReportProgress (Context);
+}
+
+/**
+  Updates a firmware device with a new firmware image.  This function returns
+  EFI_UNSUPPORTED if the firmware image is not updatable.  If the firmware image
+  is updatable, the function should perform the following minimal validations
+  before proceeding to do the firmware image update.
+    - Validate that the image is a supported image for this firmware device.
+      Return EFI_ABORTED if the image is not supported.  Additional details
+      on why the image is not a supported image may be returned in AbortReason.
+    - Validate the data from VendorCode if is not NULL.  Firmware image
+      validation must be performed before VendorCode data validation.
+      VendorCode data is ignored or considered invalid if image validation
+      fails.  Return EFI_ABORTED if the VendorCode data is invalid.
+
+  VendorCode enables vendor to implement vendor-specific firmware image update
+  policy.  Null if the caller did not specify the policy or use the default
+  policy.  As an example, vendor can implement a policy to allow an option to
+  force a firmware image update when the abort reason is due to the new firmware
+  image version is older than the current firmware image version or bad image
+  checksum.  Sensitive operations such as those wiping the entire firmware image
+  and render the device to be non-functional should be encoded in the image
+  itself rather than passed with the VendorCode.  AbortReason enables vendor to
+  have the option to provide a more detailed description of the abort reason to
+  the caller.
+
+  @param[in]  Image             Points to the new firmware image.
+  @param[in]  ImageSize         Size, in bytes, of the new firmware image.
+  @param[in]  VendorCode        This enables vendor to implement vendor-specific
+                                firmware image update policy.  NULL indicates
+                                the caller did not specify the policy or use the
+                                default policy.
+  @param[in]  Progress          A function used to report the progress of
+                                updating the firmware device with the new
+                                firmware image.
+  @param[in]  CapsuleFwVersion  The version of the new firmware image from the
+                                update capsule that provided the new firmware
+                                image.
+  @param[out] AbortReason       A pointer to a pointer to a Null-terminated
+                                Unicode string providing more details on an
+                                aborted operation. The buffer is allocated by
+                                this function with
+                                EFI_BOOT_SERVICES.AllocatePool().  It is the
+                                caller's responsibility to free this buffer with
+                                EFI_BOOT_SERVICES.FreePool().
+  @param[out] LastAttemptStatus A pointer to a UINT32 that holds the last attempt
+                                status to report back to the ESRT table in case
+                                of error. This value will only be checked when this
+                                function returns an error.
+
+                                The return status code must fall in the range of
+                                LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MIN_ERROR_CODE_VALUE to
+                                LAST_ATTEMPT_STATUS_DEVICE_LIBRARY_MAX_ERROR_CODE_VALUE.
+
+                                If the value falls outside this range, it will be converted
+                                to LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL.
+
+  @retval EFI_SUCCESS            The firmware device was successfully updated
+                                 with the new firmware image.
+  @retval EFI_ABORTED            The operation is aborted.  Additional details
+                                 are provided in AbortReason.
+  @retval EFI_INVALID_PARAMETER  The Image was NULL.
+  @retval EFI_UNSUPPORTED        The operation is not supported.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceSetImageWithStatus (
+  IN  CONST VOID                                     *Image,
+  IN  UINTN                                          ImageSize,
+  IN  CONST VOID                                     *VendorCode        OPTIONAL,
+  IN  EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Progress           OPTIONAL,
+  IN  UINT32                                         CapsuleFwVersion,
+  OUT CHAR16                                         **AbortReason,
+  OUT UINT32                                         *LastAttemptStatus
+  )
+{
+  EFI_STATUS       Status;
+  ProgressContext  ProgressCtx;
+
+  ProgressCtx.Callback     = Progress;
+  ProgressCtx.CurrentUnits = 0;
+  ProgressCtx.TotalUnits   = 0;
+  ProgressCtx.ShouldReport = TRUE;
+
+  Status = EcFlashImage (Image, ImageSize, UpdateProgress, &ProgressCtx);
+
+  //
+  // Request reset EC only in case of success to not immediately brick the
+  // device if something went wrong.
+  //
+  if (!EFI_ERROR (Status)) {
+    //
+    // The reset is postponed until the main code calls gRT->ResetSystem(),
+    // which permits storing result in UEFI variables, displaying update report
+    // to the user and proper shutdown of devices.
+    //
+    EcResetNeeded = TRUE;
+  }
+
+  return Status;
+}
+
+/**
+  Lock the firmware device that contains a firmware image.  Once a firmware
+  device is locked, any attempts to modify the firmware image contents in the
+  firmware device must fail.
+
+  @note It is recommended that all firmware devices support a lock method to
+        prevent modifications to a stored firmware image.
+
+  @note A firmware device lock mechanism is typically only cleared by a full
+        system reset (not just sleep state/low power mode).
+
+  @retval  EFI_SUCCESS      The firmware device was locked.
+  @retval  EFI_UNSUPPORTED  The firmware device does not support locking
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceLock (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  This routine is called to reset EC after its firmware was updated.
+
+  @param[in]  ResetType    The type of reset to perform.
+  @param[in]  ResetStatus  The status code for the reset.
+  @param[in]  DataSize     The size, in bytes, of ResetData.
+  @param[in]  ResetData    For a ResetType of EfiResetCold, EfiResetWarm, or
+                           EfiResetShutdown the data buffer starts with a Null-terminated
+                           string, optionally followed by additional binary data.
+                           The string is a description that the caller may use to further
+                           indicate the reason for the system reset.
+                           For a ResetType of EfiResetPlatformSpecific the data buffer
+                           also starts with a Null-terminated string that is followed
+                           by an EFI_GUID that describes the specific type of reset to perform.
+**/
+STATIC
+VOID
+EFIAPI
+PerformEcReset (
+  IN EFI_RESET_TYPE  ResetType,
+  IN EFI_STATUS      ResetStatus,
+  IN UINTN           DataSize,
+  IN VOID            *ResetData OPTIONAL
+  )
+{
+  EFI_STATUS  Status;
+
+  if (!EcResetNeeded) {
+    return;
+  }
+
+  Status = EcReset ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to reset EC!\n", __func__));
+  }
+}
+
+/**
+  Constructor to perform required initialization.
+
+  @param ImageHandle  The image handle of the process.
+  @param SystemTable  The EFI System Table pointer.
+
+  @retval EFI_SUCCESS  Initialization was successful.
+**/
+EFI_STATUS
+EFIAPI
+FmpDeviceEcLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                                      Status;
+  EDKII_PLATFORM_SPECIFIC_RESET_HANDLER_PROTOCOL  *ResetNotify;
+
+  //
+  // Using gEdkiiPlatformSpecificResetHandlerProtocolGuid instead of
+  // gEdkiiPlatformSpecificResetFilterProtocolGuid or
+  // mPlatformSpecificResetFilter because its handlers are executed last.  All
+  // three protocols are EFI_RESET_NOTIFICATION_PROTOCOL, but handlers
+  // registered with EDKII-specific ones run before/after handlers of the
+  // UEFI-defined protocol.  Should be better to run most of the handlers before
+  // rebooting.
+  //
+  Status = gBS->LocateProtocol (
+                  &gEdkiiPlatformSpecificResetHandlerProtocolGuid,
+                  NULL,
+                  (VOID **)&ResetNotify
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): can't locate protocol for reset notifications.\n"));
+  } else {
+    Status = ResetNotify->RegisterResetNotify (ResetNotify, PerformEcReset);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a(): can't register reset notification.\n"));
+    }
+  }
+
+  return Status;
+}

--- a/DasharoPayloadPkg/Library/FmpDeviceEcLib/FmpDeviceEcLib.inf
+++ b/DasharoPayloadPkg/Library/FmpDeviceEcLib/FmpDeviceEcLib.inf
@@ -1,0 +1,45 @@
+## @file
+#  Implements FmpDeviceLib for Dasharo EC.
+#
+#  Copyright (c) 2026, 3mdeb Sp. z o.o. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION     = 0x00010005
+  BASE_NAME       = FmpDeviceEcLib
+  FILE_GUID       = CE6E58D7-856F-4D89-805F-108F86DB9150
+  MODULE_TYPE     = DXE_DRIVER
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = FmpDeviceLib|DXE_DRIVER UEFI_DRIVER
+  CONSTRUCTOR     = FmpDeviceEcLibConstructor
+
+[Sources]
+  EcFlashing.c
+  FmpDeviceEcLib.c
+
+[LibraryClasses]
+  BaseMemoryLib
+  BlParseLib
+  DebugLib
+  HobLib
+  IoLib
+  MemoryAllocationLib
+  PcdLib
+  PrintLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+
+[Pcd]
+  gDasharoPayloadPkgTokenSpaceGuid.PcdEcFlashSize  ## CONSUMES
+
+[Packages]
+  DasharoPayloadPkg/DasharoPayloadPkg.dec
+  FmpDevicePkg/FmpDevicePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[Protocols]
+  gEdkiiPlatformSpecificResetHandlerProtocolGuid

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -266,6 +266,7 @@ InitCapsulePtr (
   HobPointer.Raw = GetHobList ();
   while ((HobPointer.Raw = GetNextHob (EFI_HOB_TYPE_UEFI_CAPSULE, HobPointer.Raw)) != NULL) {
     if (!IsValidCapsuleHeader ((VOID *)(UINTN)HobPointer.Capsule->BaseAddress, HobPointer.Capsule->Length)) {
+      DEBUG ((DEBUG_ERROR, "%a(): invalid capsule at 0x%x\n", __func__, HobPointer.Capsule->BaseAddress));
       HobPointer.Header->HobType = EFI_HOB_TYPE_UNUSED; // Mark this hob as invalid
     } else {
       if (IsCapsuleNameCapsule ((VOID *)(UINTN)HobPointer.Capsule->BaseAddress)) {
@@ -779,7 +780,7 @@ DoResetSystem (
   VOID
   )
 {
-  DEBUG ((DEBUG_INFO, "Capsule Request Cold Reboot."));
+  DEBUG ((DEBUG_INFO, "Capsule Request Cold Reboot.\n"));
 
   REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE | PcdGet32 (PcdStatusCodeSubClassCapsule) | PcdGet32 (PcdCapsuleStatusCodeResettingSystem)));
 

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -847,6 +847,18 @@ ProcessCapsules (
     Status = ProcessTheseCapsules (TRUE, &CapsuleReport);
 
     //
+    // Processing of mNeedReset set by the first invocation of
+    // ProcessTheseCapsules() will be handled on the second one.  Otherwise,
+    // the system hangs on displaying update report as console hasn't been
+    // initialized yet.
+    //
+    // This will make the system get further in the boot process, but when
+    // there is no FmpDxe as part of the firmware the only time a reboot happens
+    // this early is when something goes wrong (like when no capsules are
+    // discovered).
+    //
+   } else {
+    //
     // Reboot System if and only if all capsule processed.
     // If not, defer reset to 2nd process.
     //
@@ -859,7 +871,7 @@ ProcessCapsules (
       FinishCapsuleUpdate (&CapsuleReport);
       DoResetSystem ();
     }
-  } else {
+
     Status = ProcessTheseCapsules (FALSE, &CapsuleReport);
 
     FinishCapsuleUpdate (&CapsuleReport);

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -19,6 +19,9 @@
 #include <Protocol/EsrtManagement.h>
 #include <Protocol/FirmwareManagementProgress.h>
 
+#include <Guid/FmpCapsule.h>
+#include <Guid/SystemResourceTable.h>
+
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -231,6 +234,102 @@ UpdateImageProgress (
 }
 
 /**
+  Extracts GUID of the payload of an FMP capsule.
+
+  @param[in]      CapsuleHeader  Capsule to process.
+  @param[in,out]  Guid           Storage for the GUID.
+
+  @retval TRUE   Extracted GUID of the only payload.
+  @retval FALSE  The capsule is not of FMP kind.
+                 The capsule fails to validate.
+                 Number of payloads isn't exactly one.
+**/
+STATIC
+BOOLEAN
+GetPayloadGuid (
+  IN     EFI_CAPSULE_HEADER  *CapsuleHeader,
+  IN OUT EFI_GUID            *Guid
+  )
+{
+  EFI_STATUS                                    Status;
+  UINT16                                        EmbeddedDriverCount;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER        *FmpHeader;
+  EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER  *ImageHeader;
+  UINT64                                        *OffsetList;
+
+  // Basic type and contents validation are necessary for use right after
+  // capsules were discovered.
+  if (!IsFmpCapsule (CapsuleHeader)) {
+    return FALSE;
+  }
+
+  Status = ValidateFmpCapsule (CapsuleHeader, &EmbeddedDriverCount);
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  FmpHeader = (EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER *)((UINT8 *)CapsuleHeader + CapsuleHeader->HeaderSize);
+  if (FmpHeader->PayloadItemCount != 1) {
+    // Produce predictable results by rejecting capsules with multiple payloads.
+    return FALSE;
+  }
+
+  OffsetList  = (UINT64 *)&FmpHeader[1];
+  ImageHeader = (EFI_FIRMWARE_MANAGEMENT_CAPSULE_IMAGE_HEADER *)((UINT8 *)FmpHeader + OffsetList[0]);
+
+  *Guid = ImageHeader->UpdateImageTypeId;
+
+  return TRUE;
+}
+
+/**
+  Checks whether capsule corresponds to the main firmware (where EDK lives).
+
+  @param[in]  CapsuleHeader  Capsule to check.
+
+  @retval TRUE   The capsule updates the main firmware.
+  @retval FALSE  Not a main-firmware capsule or something went wrong.
+**/
+STATIC
+BOOLEAN
+IsMainFirmwareCapsule (
+  IN EFI_CAPSULE_HEADER  *CapsuleHeader
+  )
+{
+  EFI_STATUS                 Status;
+  UINTN                      Index;
+  EFI_GUID                   Guid;
+  EFI_SYSTEM_RESOURCE_ENTRY  *Esre;
+  EFI_SYSTEM_RESOURCE_TABLE  *Esrt;
+
+  if (!GetPayloadGuid (CapsuleHeader, &Guid)) {
+    return FALSE;
+  }
+
+  Status = EfiGetSystemConfigurationTable (&gEfiSystemResourceTableGuid, (VOID **)&Esrt);
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  Esre = (VOID *)&Esrt[1];
+  for (Index = 0; Index < Esrt->FwResourceCount; ++Index) {
+    if (CompareGuid (&Esre[Index].FwClass, &Guid)) {
+      return (Esre[Index].FwType == ESRT_FW_TYPE_SYSTEMFIRMWARE);
+    }
+
+    if (Esre[Index].FwType == ESRT_FW_TYPE_SYSTEMFIRMWARE) {
+      //
+      // Break to imply that the first system firmware is the main one to be
+      // consistent with FindEsre() in UpdateReport.c nearby.
+      //
+      break;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
   This function initializes the mCapsulePtr, mCapsuleStatusArray and mCapsuleTotalNumber.
 **/
 VOID
@@ -252,6 +351,7 @@ InitCapsulePtr (
   IMAGE_INFO            *CapsuleOnDiskBuf;
   EFI_HANDLE            EspFsHandle;
   UINT16                LoadOptionNumber;
+  VOID                  *Tmp;
 
   CapsuleNameNumber             = 0;
   CapsuleNameTotalNumber        = 0;
@@ -406,6 +506,37 @@ InitCapsulePtr (
     }
   } else {
     mCapsuleNamePtr = NULL;
+  }
+
+  //
+  // Move all non-system capsules to be beginning of the list as updating system
+  // firmware disables EFI variables services which breaks LoadImage() and
+  // prevents processing any other capsule with embedded drivers.
+  //
+  // Things to note:
+  //  - this is not guaranteed to work and nothing terrible will happen if it
+  //    doesn't
+  //  - this can't be made to work in general because capsules can contain
+  //    multiple payloads that can be of different kinds
+  //
+  Index2 = 0;
+  for (Index = 0; Index < mCapsuleTotalNumber; Index++) {
+    if (!IsMainFirmwareCapsule (mCapsulePtr[Index])) {
+      Tmp                 = mCapsulePtr[Index2];
+      mCapsulePtr[Index2] = mCapsulePtr[Index];
+      mCapsulePtr[Index]  = Tmp;
+
+      if (mCapsuleNamePtr != NULL) {
+        // Capsule names are in 1-to-1 correspondence with capsules, so keep
+        // them in sync.  Not really making use of the name and they may not
+        // even work, but updating is easy.
+        Tmp                     = mCapsuleNamePtr[Index2];
+        mCapsuleNamePtr[Index2] = mCapsuleNamePtr[Index];
+        mCapsuleNamePtr[Index]  = Tmp;
+      }
+
+      Index2++;
+    }
   }
 
   for (Index = 0; Index < CapsuleOnDiskNum; Index++) {


### PR DESCRIPTION
This adds implementation for updating EC in EDK.  One file in there is very much like https://github.com/Dasharo/edk2/blob/dasharo/DasharoPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c and another one is derived from https://github.com/Dasharo/coreboot/blob/dasharo/src/ec/dasharo/ec/dasharo_ec.c, so it may be easier to review by comparing the new files against those two.

The driver fixes made in coreboot are applied here as well, so makes sense to review them there where diffs are smaller.  One change added here is failing if EC didn't reach a state it should be in (coreboot just continues after hitting a timeout), which should be an improvement unless that was a conscious decision when writing coreboot driver.  There is also buffer size parameter when reading board name/version and deduplication of two functions.

The splash screen for the update mentions "EC" at the top.  No smooth progress or recovery applied here: there are already 3 attempts at flashing and amount of data is small enough for the progress to be OK as is (this also allowed to keep the code close to coreboot).

In addition to a few troubles on coreboot side, there were these:
 * Hang when there are no capsule to process.
 * `EsrtDxe` messing up ESRT.
 * EC capsule can't reboot immediately following the update to let firmware display results dialog.
 * EC capsule can't be processed after the main firmware which disables EFI variables at the end and thus breaks handling of other capsules.

Update report dialog always reports main firmware's version, maybe that needs to be updated too at some point.

coreboot PR: https://github.com/Dasharo/coreboot/pull/922
issue: https://github.com/Dasharo/dasharo-issues/issues/1758
*ref: ncm-2276*