### PR TITLE
DasharoPayloadPkg: Fix builds without TPM support

### DIFF
--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -152,6 +152,9 @@
 
 [BuildOptions]
   *_*_*_CC_FLAGS                 = -D DISABLE_NEW_DEPRECATED_INTERFACES -Wno-stringop-overflow -mno-mmx -mno-sse
+!if $(TPM_ENABLE) == TRUE
+  *_*_*_CC_FLAGS                 = -D TPM_ENABLED
+!endif
 !if $(USE_CBMEM_FOR_CONSOLE) == FALSE
   GCC:RELEASE_*_*_CC_FLAGS       = -DMDEPKG_NDEBUG
   INTEL:RELEASE_*_*_CC_FLAGS     = /D MDEPKG_NDEBUG

--- a/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/DasharoPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -1248,8 +1248,7 @@ WarnIfRecoveryBoot (
   BootLogoEnableLogo ();
 }
 
-
-
+#ifdef TPM_ENABLED
 typedef struct {
   TPM_ALG_ID AlgId;
   CHAR16    *Name;
@@ -1409,6 +1408,7 @@ WarnIfSinglePCRBank (
   DrainInput();
   BootLogoEnableLogo();
 }
+#endif
 
 STATIC
 VOID
@@ -2062,7 +2062,9 @@ PlatformBootManagerAfterConsole (
     }
   }
 
+#ifdef TPM_ENABLED
   WarnIfSinglePCRBank ();
+#endif
   WarnIfBatteryLow ();
   WarnIfRecoveryBoot ();
   WarnIfFirmwareUpdateMode ();


### PR DESCRIPTION
The PR #282 broke builds where TPM_ENABLE is FALSE. The calls to the TPM2 command libraries querying supported PCR banks do not have a null library implementation, thus an attempt to build PlatformBootManagerLib without TPM fails due to the PCR bank checks. Compile out the PCR bank check if TPM is not enabled in the build.