### PR TITLE
DasharoPayloadPkg,SecurityPkg: Add support for AMD fTPM

### DIFF
--- a/DasharoPayloadPkg/AcpiPlatformDxe/AcpiPlatform.c
+++ b/DasharoPayloadPkg/AcpiPlatformDxe/AcpiPlatform.c
@@ -112,6 +112,15 @@ InstallTablesFromXsdt (
       }
     }
 
+    // Skip TPM tables
+    if (!AsciiStrnCmp ((CHAR8 *) &CurrentTable->Signature, "TPM2", 4)) {
+      continue;
+    }
+
+    if (!AsciiStrnCmp ((CHAR8 *) &CurrentTable->Signature, "TCPA", 4)) {
+      continue;
+    }
+
     //
     // Install the XSDT tables
     //
@@ -210,6 +219,16 @@ InstallTablesFromRsdt (
         ASSERT_EFI_ERROR (Status);
       }
     }
+
+    // Skip TPM tables
+    if (!AsciiStrnCmp ((CHAR8 *) &CurrentTable->Signature, "TPM2", 4)) {
+      continue;
+    }
+
+    if (!AsciiStrnCmp ((CHAR8 *) &CurrentTable->Signature, "TCPA", 4)) {
+      continue;
+    }
+
     //
     // Install the RSDT tables
     //

--- a/DasharoPayloadPkg/DasharoPayloadPkg.dsc
+++ b/DasharoPayloadPkg/DasharoPayloadPkg.dsc
@@ -706,6 +706,11 @@ OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrd
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|100
 
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType|0xFF
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0x0000001F
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass|0xFF
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2NumberOfPCRBanks|0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xFED40000
 
   # No need to initialize TPM again, coreboot already did that
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2InitializationPolicy|0

--- a/DasharoPayloadPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/DasharoPayloadPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -35,17 +35,25 @@
   Tpm12CommandLib
   Tpm12DeviceLib
   Tpm2DeviceLib
+  HobLib
+  PcdLib
 
 [Guids]
   gEfiTpmDeviceSelectedGuid           ## PRODUCES ## GUID # Used as a PPI GUID
   gEfiTpmDeviceInstanceTpm20DtpmGuid  ## SOMETIMES_CONSUMES
   gEfiTpmDeviceInstanceTpm12Guid      ## SOMETIMES_CONSUMES
+  gUefiSystemTableInfoGuid            ## CONSUMES
 
 [Ppis]
   gPeiTpmInitializationDonePpiGuid    ## SOMETIMES_PRODUCES
 
 [Pcd]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                 ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2NumberOfPCRBanks
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress
 
 [Depex.IA32, Depex.X64]
   TRUE

--- a/DasharoPayloadPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
+++ b/DasharoPayloadPkg/Tcg/Tcg2Config/Tcg2ConfigPeim.c
@@ -14,12 +14,17 @@
 #include <PiPei.h>
 
 #include <Guid/TpmInstance.h>
+#include <Guid/SystemTableInfoGuid.h>
 #include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/PcdLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/Tpm2DeviceLib.h>
 #include <Library/Tpm12DeviceLib.h>
 #include <Library/Tpm12CommandLib.h>
 #include <Ppi/TpmInitialized.h>
+#include <IndustryStandard/Acpi.h>
+#include <IndustryStandard/Tpm2Acpi.h>
 
 STATIC CONST EFI_PEI_PPI_DESCRIPTOR mTpmSelectedPpi = {
   (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
@@ -43,6 +48,131 @@ TestTpm12 (
   return Tpm12GetCapabilityFlagVolatile (&VolatileFlags);
 }
 
+EFIAPI
+EFI_TPM2_ACPI_TABLE *
+FindTpm2TableinXsdt (
+  IN  EFI_ACPI_DESCRIPTION_HEADER   *Xsdt
+  )
+{
+  EFI_TPM2_ACPI_TABLE                             *Tpm2Table;
+  VOID                                            *CurrentTableEntry;
+  UINTN                                           CurrentTablePointer;
+  EFI_ACPI_DESCRIPTION_HEADER                     *CurrentTable;
+  UINTN                                           Index;
+  UINTN                                           NumberOfTableEntries;
+
+  NumberOfTableEntries = (Xsdt->Length -
+                           sizeof (EFI_ACPI_DESCRIPTION_HEADER)) /
+                           sizeof (UINT64);
+  for (Index = 0; Index < NumberOfTableEntries; Index++) {
+    CurrentTableEntry = (VOID *) ((UINT8 *) Xsdt +
+                          sizeof (EFI_ACPI_DESCRIPTION_HEADER) +
+                          Index * sizeof (UINT64));
+    CurrentTablePointer = (UINTN) *(UINT64 *) CurrentTableEntry;
+    CurrentTable = (EFI_ACPI_DESCRIPTION_HEADER *) CurrentTablePointer;
+
+    if (!AsciiStrnCmp ((CHAR8 *) &CurrentTable->Signature, "TPM2", 4)) {
+      Tpm2Table = (EFI_TPM2_ACPI_TABLE *)
+                    (UINTN) CurrentTablePointer;
+
+      /* Detect TPMs that are not on standard address */
+      if ((Tpm2Table->AddressOfControlArea & 0xffff0000) != 0xFED40000)
+        return Tpm2Table;
+      else
+        return NULL;
+    }
+  }
+
+  return NULL;
+}
+
+EFIAPI
+EFI_TPM2_ACPI_TABLE *
+FindTpm2TableinRsdt (
+  IN  EFI_ACPI_DESCRIPTION_HEADER   *Rsdt
+  )
+{
+  EFI_TPM2_ACPI_TABLE                             *Tpm2Table;
+  VOID                                            *CurrentTableEntry;
+  UINTN                                           CurrentTablePointer;
+  EFI_ACPI_DESCRIPTION_HEADER                     *CurrentTable;
+  UINTN                                           Index;
+  UINTN                                           NumberOfTableEntries;
+
+  NumberOfTableEntries = (Rsdt->Length -
+                           sizeof (EFI_ACPI_DESCRIPTION_HEADER)) /
+                           sizeof (UINT32);
+
+  for (Index = 0; Index < NumberOfTableEntries; Index++) {
+    CurrentTableEntry = (VOID *) ((UINT8 *) Rsdt +
+                          sizeof (EFI_ACPI_DESCRIPTION_HEADER) +
+                          Index * sizeof (UINT32));
+    CurrentTablePointer = (UINTN) *(UINT32 *) CurrentTableEntry;
+    CurrentTable = (EFI_ACPI_DESCRIPTION_HEADER *) CurrentTablePointer;
+
+    if (!AsciiStrnCmp ((CHAR8 *) &CurrentTable->Signature, "TPM2", 4)) {
+      Tpm2Table = (EFI_TPM2_ACPI_TABLE *)(UINTN) CurrentTablePointer;
+
+      /* Detect TPMs that are not on standard address */
+      if ((Tpm2Table->AddressOfControlArea != 0) && 
+          ((Tpm2Table->AddressOfControlArea & 0xffff0000) != 0xFED40000)) {
+        return Tpm2Table;
+      } else {
+        return NULL;
+      }
+    }
+  }
+
+  return NULL;
+}
+
+BOOLEAN
+CheckAmdFTpmPresence (
+  VOID
+  )
+{
+  EFI_HOB_GUID_TYPE                               *GuidHob;
+  EFI_ACPI_6_3_ROOT_SYSTEM_DESCRIPTION_POINTER    *Rsdp;
+  SYSTEM_TABLE_INFO                               *SystemTableInfo;
+  EFI_TPM2_ACPI_TABLE                             *Tpm2Table;
+
+  if (GetHobList () == NULL) {
+    return FALSE;
+  }
+
+  GuidHob = GetFirstGuidHob (&gUefiSystemTableInfoGuid);
+  ASSERT (GuidHob != NULL);
+  SystemTableInfo = (SYSTEM_TABLE_INFO *)GET_GUID_HOB_DATA (GuidHob);
+
+  if (SystemTableInfo->AcpiTableBase == 0 || SystemTableInfo->AcpiTableSize == 0) {
+    return FALSE;
+  }
+
+  Tpm2Table = NULL;
+  Rsdp = (EFI_ACPI_6_3_ROOT_SYSTEM_DESCRIPTION_POINTER *)(UINTN)SystemTableInfo->AcpiTableBase;
+  if (Rsdp->XsdtAddress) {
+    Tpm2Table = FindTpm2TableinXsdt((EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->XsdtAddress);
+  } else if (Rsdp->RsdtAddress) {
+    Tpm2Table = FindTpm2TableinRsdt((EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->RsdtAddress);
+  }
+
+  if (Tpm2Table == NULL) {
+    return FALSE;
+  }
+
+  if (Tpm2Table->AddressOfControlArea == 0) {
+    return FALSE;
+  }
+
+  if (Tpm2Table->StartMethod != EFI_TPM2_ACPI_TABLE_START_METHOD_ACPI) {
+    return FALSE;
+  }
+
+  PcdSet64S(PcdTpmBaseAddress, Tpm2Table->AddressOfControlArea - 0x40);
+
+  return TRUE;
+}
+
 /**
   The entry point for Tcg2 configuration driver.
 
@@ -59,29 +189,22 @@ Tcg2ConfigPeimEntryPoint (
   UINTN                           Size;
   EFI_STATUS                      Status;
 
-  Status = Tpm12RequestUseTpm ();
-  if (!EFI_ERROR (Status) && !EFI_ERROR (TestTpm12 ())) {
-    DEBUG ((DEBUG_INFO, "%a: TPM1.2 detected\n", __FUNCTION__));
-    Size = sizeof (gEfiTpmDeviceInstanceTpm12Guid);
-    Status = PcdSetPtrS (
-               PcdTpmInstanceGuid,
-               &Size,
-               &gEfiTpmDeviceInstanceTpm12Guid
-               );
-    ASSERT_EFI_ERROR (Status);
-  } else {
+  if (CheckAmdFTpmPresence()) {
+    PcdSet8S(PcdActiveTpmInterfaceType, Tpm2PtpInterfaceAmdCrb);
+    PcdSet8S(PcdCRBIdleByPass, 1);
+
     Status = Tpm2RequestUseTpm ();
     if (!EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "%a: TPM2 detected\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: AMD fTPM 2.0 detected\n", __FUNCTION__));
       Size = sizeof (gEfiTpmDeviceInstanceTpm20DtpmGuid);
       Status = PcdSetPtrS (
-                 PcdTpmInstanceGuid,
-                 &Size,
-                 &gEfiTpmDeviceInstanceTpm20DtpmGuid
-                 );
+                  PcdTpmInstanceGuid,
+                  &Size,
+                  &gEfiTpmDeviceInstanceTpm20DtpmGuid
+                  );
       ASSERT_EFI_ERROR (Status);
     } else {
-      DEBUG ((DEBUG_INFO, "%a: no TPM detected\n", __FUNCTION__));
+      DEBUG ((DEBUG_INFO, "%a: AMD fTPM 2.0 not detected\n", __FUNCTION__));
       //
       // If no TPM2 was detected, we still need to install
       // TpmInitializationDonePpi. Namely, Tcg2Pei will exit early upon seeing
@@ -91,6 +214,41 @@ Tcg2ConfigPeimEntryPoint (
       //
       Status = PeiServicesInstallPpi (&mTpmInitializationDonePpiList);
       ASSERT_EFI_ERROR (Status);
+    }
+  } else {
+    Status = Tpm12RequestUseTpm ();
+    if (!EFI_ERROR (Status) && !EFI_ERROR (TestTpm12 ())) {
+      DEBUG ((DEBUG_INFO, "%a: TPM1.2 detected\n", __FUNCTION__));
+      Size = sizeof (gEfiTpmDeviceInstanceTpm12Guid);
+      Status = PcdSetPtrS (
+                PcdTpmInstanceGuid,
+                &Size,
+                &gEfiTpmDeviceInstanceTpm12Guid
+                );
+      ASSERT_EFI_ERROR (Status);
+    } else {
+      Status = Tpm2RequestUseTpm ();
+      if (!EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_INFO, "%a: TPM2 detected\n", __FUNCTION__));
+        Size = sizeof (gEfiTpmDeviceInstanceTpm20DtpmGuid);
+        Status = PcdSetPtrS (
+                  PcdTpmInstanceGuid,
+                  &Size,
+                  &gEfiTpmDeviceInstanceTpm20DtpmGuid
+                  );
+        ASSERT_EFI_ERROR (Status);
+      } else {
+        DEBUG ((DEBUG_INFO, "%a: no TPM detected\n", __FUNCTION__));
+        //
+        // If no TPM2 was detected, we still need to install
+        // TpmInitializationDonePpi. Namely, Tcg2Pei will exit early upon seeing
+        // the default (all-bits-zero) contents of PcdTpmInstanceGuid, thus we have
+        // to install the PPI in its place, in order to unblock any dependent
+        // PEIMs.
+        //
+        Status = PeiServicesInstallPpi (&mTpmInitializationDonePpiList);
+        ASSERT_EFI_ERROR (Status);
+      }
     }
   }
 

--- a/SecurityPkg/Include/Library/Tpm2DeviceLib.h
+++ b/SecurityPkg/Include/Library/Tpm2DeviceLib.h
@@ -18,6 +18,7 @@ typedef enum {
   Tpm2PtpInterfaceTis,
   Tpm2PtpInterfaceFifo,
   Tpm2PtpInterfaceCrb,
+  Tpm2PtpInterfaceAmdCrb,
   Tpm2PtpInterfaceMax,
 } TPM2_PTP_INTERFACE_TYPE;
 

--- a/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -100,6 +100,35 @@ PtpCrbWaitRegisterBits (
 }
 
 /**
+  Check whether the AMD CRB TPM processed the command.
+
+  @param[in]  CrbReg       Address to teh CRB register set.
+  @param[in]  TimeOut      The max wait time (unit MicroSecond) when checking register.
+
+  @retval     EFI_SUCCESS  The register satisfies the check bit.
+  @retval     EFI_TIMEOUT  The register can't run into the expected status in time.
+**/
+EFI_STATUS
+PtpAmdCrbWaitStatus (
+  IN      PTP_CRB_REGISTERS_PTR  CrbReg,
+  IN      UINT32  TimeOut
+  )
+{
+  UINT32  WaitTime;
+
+  for (WaitTime = 0; WaitTime < TimeOut; WaitTime += 30) {
+    if (MmioRead32 ((UINTN)&CrbReg->CrbControlStart == 0) ||
+        MmioRead32 ((UINTN)&CrbReg->CrbControlStatus)) {
+      return EFI_SUCCESS;
+    }
+
+    MicroSecondDelay (30);
+  }
+
+  return EFI_TIMEOUT;
+}
+
+/**
   Get the control of TPM chip.
 
   @param[in] CrbReg                Pointer to CRB register.
@@ -119,6 +148,11 @@ PtpCrbRequestUseTpm (
 
   if (!Tpm2IsPtpPresence (CrbReg)) {
     return EFI_NOT_FOUND;
+  }
+
+  // Localities not supported on AMD fTPM.
+  if (GetCachedPtpInterface () == Tpm2PtpInterfaceAmdCrb) {
+    return EFI_SUCCESS;
   }
 
   //
@@ -147,6 +181,219 @@ PtpCrbRequestUseTpm (
              0,
              PTP_TIMEOUT_A
              );
+  return Status;
+}
+
+/**
+  Send a command to TPM for execution and return response data.
+
+  @param[in]      CrbReg        TPM register space base address.
+  @param[in]      BufferIn      Buffer for command data.
+  @param[in]      SizeIn        Size of command data.
+  @param[in, out] BufferOut     Buffer for response data.
+  @param[in, out] SizeOut       Size of response data.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_BAD_BUFFER_SIZE   Command data buffer or resposne is too big
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+PtpAmdCrbTpmCommand (
+  IN     PTP_CRB_REGISTERS_PTR  CrbReg,
+  IN     UINT8                  *BufferIn,
+  IN     UINT32                 SizeIn,
+  IN OUT UINT8                  *BufferOut,
+  IN OUT UINT32                 *SizeOut
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      Index;
+  UINT32      TpmOutSize;
+  UINT16      Data16;
+  UINT32      Data32;
+  UINT8       RetryCnt;
+  UINT64      CmdBuf;
+  UINT64      RespBuf;
+  TPM2_COMMAND_HEADER *TpmHdr;
+  TPM_CC      TpmCommandCode;
+
+  if (SizeIn > SIZE_16KB) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Input buffer bigger than TPM2 buffer!\n"));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  DEBUG_CODE_BEGIN ();
+  UINTN  DebugSize;
+
+  DEBUG ((DEBUG_VERBOSE, "PtpAmdCrbTpmCommand Send - "));
+  if (SizeIn > 0x100) {
+    DebugSize = 0x40;
+  } else {
+    DebugSize = SizeIn;
+  }
+
+  for (Index = 0; Index < DebugSize; Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
+  }
+
+  if (DebugSize != SizeIn) {
+    DEBUG ((DEBUG_VERBOSE, "...... "));
+    for (Index = SizeIn - 0x20; Index < SizeIn; Index++) {
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
+    }
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  TpmOutSize = 0;
+
+  RetryCnt = 0;
+  while (TRUE) {
+    Status = PtpCrbWaitRegisterBits (
+               &CrbReg->CrbControlStart,
+               0,
+               PTP_CRB_CONTROL_START,
+               PTP_TIMEOUT_C
+               );
+    if (EFI_ERROR (Status)) {
+      RetryCnt++;
+      if (RetryCnt < RETRY_CNT_MAX) {
+        continue;
+      } else {
+        return EFI_DEVICE_ERROR;
+      }
+    }
+    break;
+  }
+
+  CmdBuf = MmioRead32 ((UINTN)&CrbReg->CrbControlCommandAddressHigh);
+  CmdBuf = LShiftU64 (CmdBuf, 32);
+  CmdBuf |= MmioRead32 ((UINTN)&CrbReg->CrbControlCommandAddressLow);
+
+  if (CmdBuf == 0) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Command buffer is null!\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  CopyMem ((VOID *)(UINTN)CmdBuf, BufferIn, SizeIn);
+
+  RespBuf = MmioRead64 ((UINTN)&CrbReg->CrbControlResponseAddrss);
+  MmioWrite32 ((UINTN)&CrbReg->CrbControlResponseSize, SIZE_16KB);
+
+  if (RespBuf == 0) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Response buffer is null!\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  SetMem ((VOID *)(UINTN)RespBuf, SIZE_16KB, 0x0);
+
+  TpmHdr = (TPM2_COMMAND_HEADER *)(UINTN)CmdBuf;
+  TpmCommandCode = SwapBytes32 (TpmHdr->commandCode);
+
+  MmioWrite8 ((UINTN)&CrbReg->CrbControlStart, PTP_CRB_CONTROL_START);
+  if ((TpmCommandCode == TPM_CC_CreatePrimary) ||
+      (TpmCommandCode == TPM_CC_Create)) {
+    Status = PtpCrbWaitRegisterBits (
+              &CrbReg->CrbControlStart,
+              0,
+              PTP_CRB_CONTROL_START,
+              PTP_TIMEOUT_MAX
+              );
+  } else {
+    Status = PtpCrbWaitRegisterBits (
+              &CrbReg->CrbControlStart,
+              0,
+              PTP_CRB_CONTROL_START,
+              PTP_TIMEOUT_B
+              );
+  }
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Command execution failure!\n"));
+    goto AmdCrbExit;
+  }
+
+  if (MmioRead32 ((UINTN)&CrbReg->CrbControlStatus) & PTP_CRB_CONTROL_AREA_STATUS_TPM_STATUS) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Error: %08x\n", MmioRead32 ((UINTN)&CrbReg->CrbControlStatus)));
+    Status = EFI_DEVICE_ERROR;
+    goto AmdCrbExit;
+  }
+
+  RespBuf = MmioRead64 ((UINTN)&CrbReg->CrbControlResponseAddrss);
+  if (RespBuf == 0) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Response bufferafter command is null!\n"));
+    Status = EFI_DEVICE_ERROR;
+    goto AmdCrbExit;
+  }
+
+  if (*SizeOut < sizeof (TPM2_RESPONSE_HEADER)) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Output buffer to small to hold TPM2 Response Header!\n"));
+    Status = EFI_BUFFER_TOO_SMALL;
+    goto AmdCrbExit;
+  }
+
+  //
+  // Get response data header
+  //
+  CopyMem (BufferOut, (VOID *)(UINTN)RespBuf, sizeof (TPM2_RESPONSE_HEADER));
+
+  DEBUG_CODE_BEGIN ();
+  DEBUG ((DEBUG_VERBOSE, "PtpAmdCrbTpmCommand ReceiveHeader - "));
+  for (Index = 0; Index < sizeof (TPM2_RESPONSE_HEADER); Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  //
+  // Check the response data header (tag, parasize and returncode)
+  //
+  CopyMem (&Data16, BufferOut, sizeof (UINT16));
+  // TPM2 should not use this RSP_COMMAND
+  if (SwapBytes16 (Data16) == TPM_ST_RSP_COMMAND) {
+    DEBUG ((DEBUG_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
+    Status = EFI_UNSUPPORTED;
+    goto AmdCrbExit;
+  }
+
+  CopyMem (&Data32, (BufferOut + 2), sizeof (UINT32));
+  TpmOutSize = SwapBytes32 (Data32);
+  if (*SizeOut < TpmOutSize) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - Output buffer to small to hold whole TPM2 Response!\n"));
+    //
+    // Command completed, but buffer is not enough
+    //
+    Status = EFI_BUFFER_TOO_SMALL;
+    goto AmdCrbExit;
+  }
+
+  if (TpmOutSize > SIZE_16KB) {
+    DEBUG ((DEBUG_ERROR, "PtpAmdCrbTpmCommand - TPM buffer to small to hold TPM2 Response!\n"));
+    Status = EFI_BAD_BUFFER_SIZE;
+    goto AmdCrbExit;
+  }
+
+  *SizeOut = TpmOutSize;
+  //
+  // Continue reading the remaining data. For simplicity copy whole response
+  //
+  CopyMem (BufferOut, (VOID *)(UINTN)RespBuf, TpmOutSize);
+
+  DEBUG_CODE_BEGIN ();
+  DEBUG ((DEBUG_VERBOSE, "PtpAmdCrbTpmCommand Receive - "));
+  for (Index = 0; Index < TpmOutSize; Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+
+AmdCrbExit:
+  MmioWrite32 ((UINTN)&CrbReg->CrbControlCommandSize, SIZE_16KB);
+  MmioWrite32 ((UINTN)&CrbReg->CrbControlResponseSize, SIZE_16KB);
+
   return Status;
 }
 
@@ -535,45 +782,54 @@ DumpPtpInfo (
     return;
   }
 
-  InterfaceId.Uint32         = MmioRead32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
-  InterfaceCapability.Uint32 = MmioRead32 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->InterfaceCapability);
-  StatusEx                   = MmioRead8 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->StatusEx);
+  /* InterfaceID not supported on AMD fTPM */
+  PtpInterface = GetCachedPtpInterface ();
+  if (PtpInterface != Tpm2PtpInterfaceAmdCrb) {
+    InterfaceId.Uint32         = MmioRead32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+    InterfaceCapability.Uint32 = MmioRead32 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->InterfaceCapability);
+    StatusEx                   = MmioRead8 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->StatusEx);
 
-  //
-  // Dump InterfaceId Register for PTP
-  //
-  DEBUG ((DEBUG_INFO, "InterfaceId - 0x%08x\n", InterfaceId.Uint32));
-  DEBUG ((DEBUG_INFO, "  InterfaceType    - 0x%02x\n", InterfaceId.Bits.InterfaceType));
-  if (InterfaceId.Bits.InterfaceType != PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) {
-    DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%02x\n", InterfaceId.Bits.InterfaceVersion));
-    DEBUG ((DEBUG_INFO, "  CapFIFO          - 0x%x\n", InterfaceId.Bits.CapFIFO));
-    DEBUG ((DEBUG_INFO, "  CapCRB           - 0x%x\n", InterfaceId.Bits.CapCRB));
-  }
+    //
+    // Dump InterfaceId Register for PTP
+    //
+    DEBUG ((DEBUG_INFO, "InterfaceId - 0x%08x\n", InterfaceId.Uint32));
+    DEBUG ((DEBUG_INFO, "  InterfaceType    - 0x%02x\n", InterfaceId.Bits.InterfaceType));
+    if (InterfaceId.Bits.InterfaceType != PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) {
+      DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%02x\n", InterfaceId.Bits.InterfaceVersion));
+      DEBUG ((DEBUG_INFO, "  CapFIFO          - 0x%x\n", InterfaceId.Bits.CapFIFO));
+      DEBUG ((DEBUG_INFO, "  CapCRB           - 0x%x\n", InterfaceId.Bits.CapCRB));
+    }
 
-  //
-  // Dump Capability Register for TIS and FIFO
-  //
-  DEBUG ((DEBUG_INFO, "InterfaceCapability - 0x%08x\n", InterfaceCapability.Uint32));
-  if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) ||
-      (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO))
-  {
-    DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%x\n", InterfaceCapability.Bits.InterfaceVersion));
-  }
+    //
+    // Dump Capability Register for TIS and FIFO
+    //
+    DEBUG ((DEBUG_INFO, "InterfaceCapability - 0x%08x\n", InterfaceCapability.Uint32));
+    if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) ||
+        (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO))
+    {
+      DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%x\n", InterfaceCapability.Bits.InterfaceVersion));
+    }
 
-  //
-  // Dump StatusEx Register for PTP FIFO
-  //
-  DEBUG ((DEBUG_INFO, "StatusEx - 0x%02x\n", StatusEx));
-  if (InterfaceCapability.Bits.InterfaceVersion == INTERFACE_CAPABILITY_INTERFACE_VERSION_PTP) {
-    DEBUG ((DEBUG_INFO, "  TpmFamily - 0x%x\n", (StatusEx & PTP_FIFO_STS_EX_TPM_FAMILY) >> PTP_FIFO_STS_EX_TPM_FAMILY_OFFSET));
+    //
+    // Dump StatusEx Register for PTP FIFO
+    //
+    DEBUG ((DEBUG_INFO, "StatusEx - 0x%02x\n", StatusEx));
+    if (InterfaceCapability.Bits.InterfaceVersion == INTERFACE_CAPABILITY_INTERFACE_VERSION_PTP) {
+      DEBUG ((DEBUG_INFO, "  TpmFamily - 0x%x\n", (StatusEx & PTP_FIFO_STS_EX_TPM_FAMILY) >> PTP_FIFO_STS_EX_TPM_FAMILY_OFFSET));
+    }
+
   }
 
   Vid          = 0xFFFF;
   Did          = 0xFFFF;
   Rid          = 0xFF;
-  PtpInterface = GetCachedPtpInterface ();
   DEBUG ((DEBUG_INFO, "PtpInterface - %x\n", PtpInterface));
   switch (PtpInterface) {
+    case Tpm2PtpInterfaceAmdCrb:
+      Vid = 0x1022; // AMD PCI ID
+      Did = 0;
+      Rid = 0;
+      break;
     case Tpm2PtpInterfaceCrb:
       Vid = MmioRead16 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->Vid);
       Did = MmioRead16 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->Did);
@@ -619,6 +875,14 @@ DTpm2SubmitCommand (
 
   PtpInterface = GetCachedPtpInterface ();
   switch (PtpInterface) {
+    case Tpm2PtpInterfaceAmdCrb:
+      return PtpAmdCrbTpmCommand (
+               (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress),
+               InputParameterBlock,
+               InputParameterBlockSize,
+               OutputParameterBlock,
+               OutputParameterBlockSize
+               );
     case Tpm2PtpInterfaceCrb:
       return PtpCrbTpmCommand (
                (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress),
@@ -658,6 +922,7 @@ DTpm2RequestUseTpm (
 
   PtpInterface = GetCachedPtpInterface ();
   switch (PtpInterface) {
+    case Tpm2PtpInterfaceAmdCrb:
     case Tpm2PtpInterfaceCrb:
       return PtpCrbRequestUseTpm ((PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress));
     case Tpm2PtpInterfaceFifo:

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -582,6 +582,7 @@
   #  0x00 - FIFO interface as defined in TIS 1.3 is active.<BR>
   #  0x01 - FIFO interface as defined in PTP for TPM 2.0 is active.<BR>
   #  0x02 - CRB interface is active.<BR>
+  #  0x03 - AMD fTPM CRB interface is active.<BR>
   #  0xFF - Contains no current active TPM interface type.<BR>
   #
   # @Prompt current active TPM interface type.

--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.c
@@ -40,6 +40,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/Tpm2CommandLib.h>
 #include <Library/UefiLib.h>
 #include <Library/HobLib.h>
+#include <Library/IoLib.h>
 
 //
 // Physical Presence Interface Version supported by Platform
@@ -828,6 +829,10 @@ PublishTpm2 (
 
   InterfaceType = PcdGet8 (PcdActiveTpmInterfaceType);
   switch (InterfaceType) {
+    case Tpm2PtpInterfaceAmdCrb:
+      mTpm2AcpiTemplate.StartMethod          = EFI_TPM2_ACPI_TABLE_START_METHOD_ACPI;
+      mTpm2AcpiTemplate.AddressOfControlArea = PcdGet64 (PcdTpmBaseAddress) + 0x40;
+      break;
     case Tpm2PtpInterfaceCrb:
       mTpm2AcpiTemplate.StartMethod          = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE;
       mTpm2AcpiTemplate.AddressOfControlArea = PcdGet64 (PcdTpmBaseAddress) + 0x40;

--- a/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.inf
+++ b/SecurityPkg/Tcg/Tcg2Acpi/Tcg2Acpi.inf
@@ -58,6 +58,7 @@
   Tcg2PhysicalPresenceLib
   PcdLib
   HobLib
+  IoLib
 
 [Guids]
   gEfiTpmDeviceInstanceTpm20DtpmGuid                            ## PRODUCES           ## GUID       # TPM device identifier

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigImpl.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigImpl.c
@@ -961,6 +961,7 @@ InstallTcg2ConfigForm (
       case Tpm2PtpInterfaceFifo:
         HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT), L"PTP FIFO", NULL);
         break;
+      case Tpm2PtpInterfaceAmdCrb:
       case Tpm2PtpInterfaceCrb:
         HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT), L"PTP CRB", NULL);
         break;
@@ -975,6 +976,11 @@ InstallTcg2ConfigForm (
         Tcg2ConfigInfo.TpmDeviceInterfacePtpFifoSupported = FALSE;
         Tcg2ConfigInfo.TpmDeviceInterfacePtpCrbSupported  = FALSE;
         HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT), L"TIS", NULL);
+        break;
+      case Tpm2PtpInterfaceAmdCrb:
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpFifoSupported = FALSE;
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpCrbSupported  = TRUE;
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT), L"PTP CRB", NULL);
         break;
       case Tpm2PtpInterfaceFifo:
       case Tpm2PtpInterfaceCrb:

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -2868,6 +2868,10 @@ PublishTpm2 (
 
   InterfaceType = PcdGet8(PcdActiveTpmInterfaceType);
   switch (InterfaceType) {
+  case Tpm2PtpInterfaceAmdCrb:
+    mTpm2AcpiTemplate.StartMethod          = EFI_TPM2_ACPI_TABLE_START_METHOD_ACPI;
+    mTpm2AcpiTemplate.AddressOfControlArea = PcdGet64 (PcdTpmBaseAddress) + 0x40;
+    break;
   case Tpm2PtpInterfaceCrb:
     mTpm2AcpiTemplate.StartMethod = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE;
     mTpm2AcpiTemplate.AddressOfControlArea = PcdGet64 (PcdTpmBaseAddress) + 0x40;


### PR DESCRIPTION
Depend on the TPM2 ACPI table published by coreboot to get the AMD fTPM control area address. If the address is not in the standard TPM address space, assume it is AMD fTPM.

Ensure the TPM2 and TCPA tables are not installed in the Platform ACPI driver. This will ensure the event log is properly populated and TPM2 ACPI table is installed by Tcg2Acpi even if coreboot publishes ACPI TPM2/TCPA tables.

Add handling of CRB command processing in the TPM2 device library and omit touching registers that do not exist on AMD fTPM.

TEST=On MSI PRO B850-P WIFI change PCR banks, read PCRs on Linux, check TPM device has no problems in Device Manager on Windows.